### PR TITLE
Speed improvements

### DIFF
--- a/lammps_plugin/ML-UF3/.clang-format
+++ b/lammps_plugin/ML-UF3/.clang-format
@@ -1,0 +1,32 @@
+---
+Language:                             Cpp
+BasedOnStyle:                         LLVM
+AccessModifierOffset:                 -1
+AlignConsecutiveAssignments:          false
+AlignConsecutiveDeclarations:         false
+AlignEscapedNewlines:                 Left
+AlignOperands:                        false
+AllowShortBlocksOnASingleLine:        true
+AllowShortFunctionsOnASingleLine:     Inline
+AllowShortIfStatementsOnASingleLine:  WithoutElse
+AllowShortLambdasOnASingleLine:       None
+AllowShortLoopsOnASingleLine:         true
+BraceWrapping:
+  AfterFunction:                      true
+BreakBeforeBraces:                    Custom
+BreakConstructorInitializers:         AfterColon
+BreakInheritanceList:                 AfterColon
+ColumnLimit:                          100
+IndentCaseLabels:                     true
+IndentWidth:                          2
+NamespaceIndentation:                 Inner
+ObjCBlockIndentWidth:                 2
+PenaltyBreakAssignment:               4
+ReflowComments:                       false
+SpaceAfterCStyleCast:                 true
+SpacesBeforeTrailingComments:         4
+SpacesInContainerLiterals:            false
+Standard:                             Cpp11
+TabWidth:                             2
+UseTab:                               Never
+...

--- a/lammps_plugin/ML-UF3/pair_uf3.cpp
+++ b/lammps_plugin/ML-UF3/pair_uf3.cpp
@@ -20,12 +20,12 @@
 #include "uf3_triplet_bspline.h"
 
 #include "atom.h"
-#include "memory.h"
+#include "comm.h"
 #include "error.h"
+#include "force.h"
+#include "memory.h"
 #include "neigh_list.h"
 #include "neighbor.h"
-#include "force.h"
-#include "comm.h"
 #include "text_file_reader.h"
 
 #include <cmath>
@@ -34,97 +34,114 @@ using namespace LAMMPS_NS;
 
 PairUF3::PairUF3(LAMMPS *lmp) : Pair(lmp)
 {
-  single_enable = 0; // 1 if single() routine exists
-  restartinfo = 0;  // 1 if pair style writes restart info
+  single_enable = 1;    // 1 if single() routine exists
+  restartinfo = 0;      // 1 if pair style writes restart info
   maxshort = 10;
   neighshort = nullptr;
+  centroidstressflag = 4;
+  manybody_flag = 1;
+  one_coeff = 1;
 }
 
 PairUF3::~PairUF3()
 {
   if (copymode) return;
-  if (allocated)
-  {
+  if (allocated) {
     memory->destroy(setflag);
     memory->destroy(cutsq);
-    //memory->destroy(cutsq_2b);
-    if (pot_3b){
-    memory->destroy(setflag_3b);
-    memory->destroy(cut_3b);
-    memory->destroy(cut_3b_list);
-    memory->destroy(neighshort);
+    // memory->destroy(cutsq_2b);
+    if (pot_3b) {
+      memory->destroy(setflag_3b);
+      memory->destroy(cut_3b);
+      memory->destroy(cut_3b_list);
+      memory->destroy(neighshort);
     }
   }
 }
 
 /* ----------------------------------------------------------------------
  *     global settings
- *     ------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------- */
 
 void PairUF3::settings(int narg, char **arg)
 {
-  if (narg!=2) error->all(FLERR, "UF3: Invalid number of argument in pair settings\n\
+
+  utils::logmesg(lmp, "\nUF3: new splines");
+
+  if (narg != 2)
+    error->all(FLERR, "UF3: Invalid number of argument in pair settings\n\
             Are you running 2-bordy or 2 & 3-body UF potential\n\
             Also how many elements?");
-  nbody_flag = utils::numeric(FLERR,arg[0],true,lmp);
-  num_of_elements = utils::numeric(FLERR,arg[1],true,lmp);//atom->ntypes;
-  if (num_of_elements!=atom->ntypes){
-    if(comm->me==0) utils::logmesg(lmp,"\nUF3: Number of elements provided in the input file and \
+  nbody_flag = utils::numeric(FLERR, arg[0], true, lmp);
+  num_of_elements = utils::numeric(FLERR, arg[1], true, lmp);    // atom->ntypes;
+  if (num_of_elements != atom->ntypes) {
+    if (comm->me == 0)
+      utils::logmesg(lmp, "\nUF3: Number of elements provided in the input file and \
 number of elements detected by lammps in the structure are not same\n\
-     proceed with caution"); 
+     proceed with caution");
   }
-  if (nbody_flag == 2){
+  if (nbody_flag == 2) {
     pot_3b = false;
-    n2body_pot_files = num_of_elements*(num_of_elements+1)/2;
+    n2body_pot_files = num_of_elements * (num_of_elements + 1) / 2;
     tot_pot_files = n2body_pot_files;
-  }
-  else if (nbody_flag == 3){
+  } else if (nbody_flag == 3) {
     pot_3b = true;
-    n2body_pot_files = num_of_elements*(num_of_elements+1)/2;
-    n3body_pot_files = num_of_elements*(num_of_elements*(num_of_elements+1)/2);
+    n2body_pot_files = num_of_elements * (num_of_elements + 1) / 2;
+    n3body_pot_files = num_of_elements * (num_of_elements * (num_of_elements + 1) / 2);
     tot_pot_files = n2body_pot_files + n3body_pot_files;
-  }
-  else error->all(FLERR, "UF3: UF3 not yet implemented for {}-body",nbody_flag);
+  } else
+    error->all(FLERR, "UF3: UF3 not yet implemented for {}-body", nbody_flag);
 }
 
 /* ----------------------------------------------------------------------
  *    set coeffs for one or more type pairs
- *    ------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------- */
 void PairUF3::coeff(int narg, char **arg)
 {
   if (!allocated) allocate();
-  if (narg!=tot_pot_files+2) error->all(FLERR, "UF3: UF3 invalid number of argument in pair coeff; Number of potential files provided is not correct");
+  if (narg != tot_pot_files + 2)
+    error->all(FLERR,
+               "UF3: UF3 invalid number of argument in pair coeff; Number of potential files "
+               "provided is not correct");
   // open UF3 potential file on proc 0
-  for(int i=2; i<narg; i++){
-      uf3_read_pot_file(arg[i]);
-  }
-  //setflag check needed here
-  for (int i =1;i<num_of_elements+1;i++){
-    for (int j=1;j<num_of_elements+1;j++){
-      if (setflag[i][j]!=1) error->all(FLERR, "UF3: Not all 2-body UF potentials are set, missing potential file for {}-{} interaction",i,j);
+  for (int i = 2; i < narg; i++) { uf3_read_pot_file(arg[i]); }
+  // setflag check needed here
+  for (int i = 1; i < num_of_elements + 1; i++) {
+    for (int j = 1; j < num_of_elements + 1; j++) {
+      if (setflag[i][j] != 1)
+        error->all(FLERR,
+                   "UF3: Not all 2-body UF potentials are set, missing potential file for {}-{} "
+                   "interaction",
+                   i, j);
     }
   }
-  if (pot_3b){
-    for (int i =1;i<num_of_elements+1;i++){
-      for (int j=1;j<num_of_elements+1;j++){
-        for (int k=1;k<num_of_elements+1;k++){
-          if(setflag_3b[i][j][k]!=1) error->all(FLERR, "UF3: Not all 3-body UF potentials are set, missing potential file for {}-{}-{} interaction",i,j,k);
+  if (pot_3b) {
+    for (int i = 1; i < num_of_elements + 1; i++) {
+      for (int j = 1; j < num_of_elements + 1; j++) {
+        for (int k = 1; k < num_of_elements + 1; k++) {
+          if (setflag_3b[i][j][k] != 1)
+            error->all(FLERR,
+                       "UF3: Not all 3-body UF potentials are set, missing potential file for "
+                       "{}-{}-{} interaction",
+                       i, j, k);
         }
       }
     }
   }
-  for (int i =1;i<num_of_elements+1;i++){
-    for (int j=i;j<num_of_elements+1;j++){
-      UFBS2b[i][j] = uf3_pair_bspline(lmp,3,n2b_knot[i][j], n2b_coeff[i][j]);
-      UFBS2b[j][i] = uf3_pair_bspline(lmp,3,n2b_knot[j][i], n2b_coeff[j][i]);
+  for (int i = 1; i < num_of_elements + 1; i++) {
+    for (int j = i; j < num_of_elements + 1; j++) {
+      UFBS2b[i][j] = uf3_pair_bspline(lmp, 3, n2b_knot[i][j], n2b_coeff[i][j]);
+      UFBS2b[j][i] = uf3_pair_bspline(lmp, 3, n2b_knot[j][i], n2b_coeff[j][i]);
     }
-    if (pot_3b){
-      for (int j=1;j<num_of_elements+1;j++){
-        for (int k=j;k<num_of_elements+1;k++){
-          key = std::to_string(i)+std::to_string(j)+std::to_string(k);
-          UFBS3b[i][j][k] = uf3_triplet_bspline(lmp,n3b_knot_matrix[i][j][k],n3b_coeff_matrix[key]);
-          key = std::to_string(i)+std::to_string(k)+std::to_string(j); 
-          UFBS3b[i][k][j] = uf3_triplet_bspline(lmp,n3b_knot_matrix[i][k][j],n3b_coeff_matrix[key]);
+    if (pot_3b) {
+      for (int j = 1; j < num_of_elements + 1; j++) {
+        for (int k = j; k < num_of_elements + 1; k++) {
+          key = std::to_string(i) + std::to_string(j) + std::to_string(k);
+          UFBS3b[i][j][k] =
+              uf3_triplet_bspline(lmp, n3b_knot_matrix[i][j][k], n3b_coeff_matrix[key]);
+          key = std::to_string(i) + std::to_string(k) + std::to_string(j);
+          UFBS3b[i][k][j] =
+              uf3_triplet_bspline(lmp, n3b_knot_matrix[i][k][j], n3b_coeff_matrix[key]);
         }
       }
     }
@@ -134,90 +151,96 @@ void PairUF3::coeff(int narg, char **arg)
 void PairUF3::allocate()
 {
   allocated = 1;
-  //Contains info about wether UF potential were found for type i and j
-  memory->create(setflag,num_of_elements+1,num_of_elements+1,"pair:setflag");
-  //Contains info about 2-body cutoff distance for type i and j
-  memory->create(cutsq,num_of_elements+1,num_of_elements+1,"pair:cutsq");
-  //memory->create(cutsq_2b,num_of_elements+1,num_of_elements+1,"pair:cutsq_2b");
-  //Contains knot_vect of 2-body potential for type i and j
-  n2b_knot.resize(num_of_elements+1);
-  n2b_coeff.resize(num_of_elements+1);
-  UFBS2b.resize(num_of_elements+1);
-  for(int i =1; i<num_of_elements+1; i++){
-   n2b_knot[i].resize(num_of_elements+1);
-   n2b_coeff[i].resize(num_of_elements+1);
-   UFBS2b[i].resize(num_of_elements+1);
+  // Contains info about wether UF potential were found for type i and j
+  memory->create(setflag, num_of_elements + 1, num_of_elements + 1, "pair:setflag");
+  // Contains info about 2-body cutoff distance for type i and j
+  memory->create(cutsq, num_of_elements + 1, num_of_elements + 1, "pair:cutsq");
+  // memory->create(cutsq_2b,num_of_elements+1,num_of_elements+1,"pair:cutsq_2b");
+  // Contains knot_vect of 2-body potential for type i and j
+  n2b_knot.resize(num_of_elements + 1);
+  n2b_coeff.resize(num_of_elements + 1);
+  UFBS2b.resize(num_of_elements + 1);
+  for (int i = 1; i < num_of_elements + 1; i++) {
+    n2b_knot[i].resize(num_of_elements + 1);
+    n2b_coeff[i].resize(num_of_elements + 1);
+    UFBS2b[i].resize(num_of_elements + 1);
   }
-  if(pot_3b)
-  {
-    //Contains info about wether UF potential were found for type i, j and k
-    memory->create(setflag_3b,num_of_elements+1,num_of_elements+1,num_of_elements+1,"pair:setflag_3b");
-    //Contains info about 3-body cutoff distance for type i, j and k
-    memory->create(cut_3b,num_of_elements+1,num_of_elements+1,num_of_elements+1,"pair:cut_3b");
-    //Contains info about 3-body cutoff distance for type i, j and k
-    //for constructing 3-body list
-    memory->create(cut_3b_list,num_of_elements+1,num_of_elements+1,"pair:cut_3b_list");
-    //setting cut_3b and setflag = 0
-    for(int i =1; i<num_of_elements+1; i++){
-      for(int j =1; j<num_of_elements+1; j++){
+  if (pot_3b) {
+    // Contains info about wether UF potential were found for type i, j and k
+    memory->create(setflag_3b, num_of_elements + 1, num_of_elements + 1, num_of_elements + 1,
+                   "pair:setflag_3b");
+    // Contains info about 3-body cutoff distance for type i, j and k
+    memory->create(cut_3b, num_of_elements + 1, num_of_elements + 1, num_of_elements + 1,
+                   "pair:cut_3b");
+    // Contains info about 3-body cutoff distance for type i, j and k
+    // for constructing 3-body list
+    memory->create(cut_3b_list, num_of_elements + 1, num_of_elements + 1, "pair:cut_3b_list");
+    // setting cut_3b and setflag = 0
+    for (int i = 1; i < num_of_elements + 1; i++) {
+      for (int j = 1; j < num_of_elements + 1; j++) {
         cut_3b_list[i][j] = 0;
-        for(int k=1;k<num_of_elements+1; k++) cut_3b[i][j][k] = 0;
+        for (int k = 1; k < num_of_elements + 1; k++) cut_3b[i][j][k] = 0;
       }
     }
-    n3b_knot_matrix.resize(num_of_elements+1);
-    UFBS3b.resize(num_of_elements+1);
-    for(int i =1; i<num_of_elements+1; i++){
-      n3b_knot_matrix[i].resize(num_of_elements+1);
-      UFBS3b[i].resize(num_of_elements+1);
-      for(int j =1; j<num_of_elements+1; j++){
-        n3b_knot_matrix[i][j].resize(num_of_elements+1);
-        UFBS3b[i][j].resize(num_of_elements+1);
+    n3b_knot_matrix.resize(num_of_elements + 1);
+    UFBS3b.resize(num_of_elements + 1);
+    for (int i = 1; i < num_of_elements + 1; i++) {
+      n3b_knot_matrix[i].resize(num_of_elements + 1);
+      UFBS3b[i].resize(num_of_elements + 1);
+      for (int j = 1; j < num_of_elements + 1; j++) {
+        n3b_knot_matrix[i][j].resize(num_of_elements + 1);
+        UFBS3b[i][j].resize(num_of_elements + 1);
       }
     }
-    memory->create(neighshort,maxshort,"pair:neighshort");
+    memory->create(neighshort, maxshort, "pair:neighshort");
   }
 }
 
 void PairUF3::uf3_read_pot_file(char *potf_name)
 {
-  if(comm->me==0) utils::logmesg(lmp,"\nUF3: Opening {} file\n",potf_name);
-  
-  FILE * fp;
-  fp = utils::open_potential(potf_name,lmp,nullptr);
-  //if (fp) error->all(FLERR,"UF3: {} file not found",potf_name);
+  if (comm->me == 0) utils::logmesg(lmp, "\nUF3: Opening {} file\n", potf_name);
 
-  TextFileReader txtfilereader(fp,"UF3:POTFP");
+  FILE *fp;
+  fp = utils::open_potential(potf_name, lmp, nullptr);
+  // if (fp) error->all(FLERR,"UF3: {} file not found",potf_name);
+
+  TextFileReader txtfilereader(fp, "UF3:POTFP");
   txtfilereader.ignore_comments = false;
-  
+
   std::string temp_line = txtfilereader.next_line(2);
   Tokenizer fp1st_line(temp_line);
-  
-  if (fp1st_line.contains("#UF3 POT")==0) error->all(FLERR, "UF3: {} file is not UF3 POT type, found type {} {} on the file"
-							,potf_name,fp1st_line.next(),fp1st_line.next());
-  
-  if(comm->me==0) utils::logmesg(lmp,"UF3: {} file is of type {} {}\n",potf_name,fp1st_line.next(),fp1st_line.next());
-  
+
+  if (fp1st_line.contains("#UF3 POT") == 0)
+    error->all(FLERR, "UF3: {} file is not UF3 POT type, found type {} {} on the file", potf_name,
+               fp1st_line.next(), fp1st_line.next());
+
+  if (comm->me == 0)
+    utils::logmesg(lmp, "UF3: {} file is of type {} {}\n", potf_name, fp1st_line.next(),
+                   fp1st_line.next());
+
   temp_line = txtfilereader.next_line(1);
   Tokenizer fp2nd_line(temp_line);
-  if (fp2nd_line.contains("2B")==1){
+  if (fp2nd_line.contains("2B") == 1) {
     temp_line = txtfilereader.next_line(4);
     ValueTokenizer fp3rd_line(temp_line);
     temp_type1 = fp3rd_line.next_int();
     temp_type2 = fp3rd_line.next_int();
-    if(comm->me==0) utils::logmesg(lmp,"UF3: {} file contains 2-body UF3 potential for {} {}\n",potf_name,temp_type1,temp_type2);
+    if (comm->me == 0)
+      utils::logmesg(lmp, "UF3: {} file contains 2-body UF3 potential for {} {}\n", potf_name,
+                     temp_type1, temp_type2);
 
-    cutsq[temp_type1][temp_type2] = pow(fp3rd_line.next_double(),2);
-    //if(comm->me==0) utils::logmesg(lmp,"UF3: Cutoff {}\n",cutsq[temp_type1][temp_type2]);
+    cutsq[temp_type1][temp_type2] = pow(fp3rd_line.next_double(), 2);
+    // if(comm->me==0) utils::logmesg(lmp,"UF3: Cutoff {}\n",cutsq[temp_type1][temp_type2]);
     cutsq[temp_type2][temp_type1] = cutsq[temp_type1][temp_type2];
-    
+
     temp_line_len = fp3rd_line.next_int();
 
-    temp_line = txtfilereader.next_line(temp_line_len);     
+    temp_line = txtfilereader.next_line(temp_line_len);
     ValueTokenizer fp4th_line(temp_line);
 
     n2b_knot[temp_type1][temp_type2].resize(temp_line_len);
     n2b_knot[temp_type2][temp_type1].resize(temp_line_len);
-    for(int k=0;k<temp_line_len;k++){
+    for (int k = 0; k < temp_line_len; k++) {
       n2b_knot[temp_type1][temp_type2][k] = fp4th_line.next_double();
       n2b_knot[temp_type2][temp_type1][k] = n2b_knot[temp_type1][temp_type2][k];
     }
@@ -226,88 +249,91 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
     ValueTokenizer fp5th_line(temp_line);
 
     temp_line_len = fp5th_line.next_int();
-    
+
     temp_line = txtfilereader.next_line(temp_line_len);
-    //utils::logmesg(lmp,"UF3:11 {}",temp_line);
+    // utils::logmesg(lmp,"UF3:11 {}",temp_line);
     ValueTokenizer fp6th_line(temp_line);
-    //if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",temp_line_len);
+    // if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",temp_line_len);
     n2b_coeff[temp_type1][temp_type2].resize(temp_line_len);
     n2b_coeff[temp_type2][temp_type1].resize(temp_line_len);
-    
-    for(int k=0;k<temp_line_len;k++){
+
+    for (int k = 0; k < temp_line_len; k++) {
       n2b_coeff[temp_type1][temp_type2][k] = fp6th_line.next_double();
       n2b_coeff[temp_type2][temp_type1][k] = n2b_coeff[temp_type1][temp_type2][k];
-      //if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][k]);
+      // if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][k]);
     }
-    //for(int i=0;i<n2b_coeff[temp_type1][temp_type2].size();i++) if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][i]);
-    if(n2b_knot[temp_type1][temp_type2].size()!=n2b_coeff[temp_type1][temp_type2].size()+4){
-      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",potf_name);
+    // for(int i=0;i<n2b_coeff[temp_type1][temp_type2].size();i++) if(comm->me==0) utils::logmesg(lmp,"UF3: {}\n",n2b_coeff[temp_type1][temp_type2][i]);
+    if (n2b_knot[temp_type1][temp_type2].size() != n2b_coeff[temp_type1][temp_type2].size() + 4) {
+      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",
+                 potf_name);
     }
     setflag[temp_type1][temp_type2] = 1;
     setflag[temp_type2][temp_type1] = 1;
-  }
-  else if (fp2nd_line.contains("3B")==1){
+  } else if (fp2nd_line.contains("3B") == 1) {
     temp_line = txtfilereader.next_line(9);
     ValueTokenizer fp3rd_line(temp_line);
     temp_type1 = fp3rd_line.next_int();
     temp_type2 = fp3rd_line.next_int();
     temp_type3 = fp3rd_line.next_int();
-    if(comm->me==0) utils::logmesg(lmp,"UF3: {} file contains 3-body UF3 potential for {} {} {}\n",
-					potf_name,temp_type1,temp_type2,temp_type3);
-    
+    if (comm->me == 0)
+      utils::logmesg(lmp, "UF3: {} file contains 3-body UF3 potential for {} {} {}\n", potf_name,
+                     temp_type1, temp_type2, temp_type3);
+
     cut3b_rjk = fp3rd_line.next_double();
     cut3b_rij = fp3rd_line.next_double();
-    //cut_3b[temp_type1][temp_type2] = std::max(cut3b_rij,
-					//cut_3b[temp_type1][temp_type2]);
-    cut_3b_list[temp_type1][temp_type2] = std::max(cut3b_rij,
-					cut_3b_list[temp_type1][temp_type2]);
+    // cut_3b[temp_type1][temp_type2] = std::max(cut3b_rij,
+    // cut_3b[temp_type1][temp_type2]);
+    cut_3b_list[temp_type1][temp_type2] = std::max(cut3b_rij, cut_3b_list[temp_type1][temp_type2]);
     cut3b_rik = fp3rd_line.next_double();
-    if (cut3b_rij!=cut3b_rik){
+    if (cut3b_rij != cut3b_rik) {
       error->all(FLERR, "UF3: rij!=rik, Current implementation only works for rij=rik");
     }
-    if (2*cut3b_rik!=cut3b_rjk){
-      error->all(FLERR, "UF3: 2rij=2rik!=rik, Current implementation only works for 2rij=2rik!=rik");
+    if (2 * cut3b_rik != cut3b_rjk) {
+      error->all(FLERR,
+                 "UF3: 2rij=2rik!=rik, Current implementation only works for 2rij=2rik!=rik");
     }
-    //cut_3b[temp_type1][temp_type3] = std::max(cut_3b[temp_type1][temp_type3],cut3b_rik);
-    cut_3b_list[temp_type1][temp_type3] = std::max(cut_3b_list[temp_type1][temp_type3],cut3b_rik);
+    // cut_3b[temp_type1][temp_type3] = std::max(cut_3b[temp_type1][temp_type3],cut3b_rik);
+    cut_3b_list[temp_type1][temp_type3] = std::max(cut_3b_list[temp_type1][temp_type3], cut3b_rik);
     cut_3b[temp_type1][temp_type2][temp_type3] = cut3b_rij;
     cut_3b[temp_type1][temp_type3][temp_type2] = cut3b_rik;
-    
+
     temp_line_len = fp3rd_line.next_int();
     temp_line = txtfilereader.next_line(temp_line_len);
     ValueTokenizer fp4th_line(temp_line);
-    
+
     n3b_knot_matrix[temp_type1][temp_type2][temp_type3].resize(3);
     n3b_knot_matrix[temp_type1][temp_type3][temp_type2].resize(3);
 
     n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0].resize(temp_line_len);
     n3b_knot_matrix[temp_type1][temp_type3][temp_type2][0].resize(temp_line_len);
-    for(int i=0;i<temp_line_len;i++){
+    for (int i = 0; i < temp_line_len; i++) {
       n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0][i] = fp4th_line.next_double();
-      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][0][i] = n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0][i];
+      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][0][i] =
+          n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0][i];
     }
-    
+
     temp_line_len = fp3rd_line.next_int();
     temp_line = txtfilereader.next_line(temp_line_len);
     ValueTokenizer fp5th_line(temp_line);
     n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1].resize(temp_line_len);
     n3b_knot_matrix[temp_type1][temp_type3][temp_type2][1].resize(temp_line_len);
-    for(int i=0;i<temp_line_len;i++){
+    for (int i = 0; i < temp_line_len; i++) {
       n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1][i] = fp5th_line.next_double();
-      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][1][i] = n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1][i];
+      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][1][i] =
+          n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1][i];
     }
-    
 
     temp_line_len = fp3rd_line.next_int();
     temp_line = txtfilereader.next_line(temp_line_len);
     ValueTokenizer fp6th_line(temp_line);
     n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2].resize(temp_line_len);
     n3b_knot_matrix[temp_type1][temp_type3][temp_type2][2].resize(temp_line_len);
-    for(int i=0;i<temp_line_len;i++){
+    for (int i = 0; i < temp_line_len; i++) {
       n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2][i] = fp6th_line.next_double();
-      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][2][i] = n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2][i];
+      n3b_knot_matrix[temp_type1][temp_type3][temp_type2][2][i] =
+          n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2][i];
     }
-    
+
     /*if(comm->me==0){
     utils::logmesg(lmp,"UF3: knot_matrix\n");
     for(int i=0;i<3;i++){
@@ -316,40 +342,48 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
       }
       utils::logmesg(lmp,"\n");
     }}*/
- 
+
     temp_line = txtfilereader.next_line(3);
     ValueTokenizer fp7th_line(temp_line);
-    
+
     coeff_matrix_dim1 = fp7th_line.next_int();
     coeff_matrix_dim2 = fp7th_line.next_int();
     coeff_matrix_dim3 = fp7th_line.next_int();
-    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0].size()!=coeff_matrix_dim3+3+1){
-      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",potf_name);
+    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][0].size() !=
+        coeff_matrix_dim3 + 3 + 1) {
+      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",
+                 potf_name);
     }
-    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1].size()!=coeff_matrix_dim2+3+1){
-      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",potf_name);
+    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][1].size() !=
+        coeff_matrix_dim2 + 3 + 1) {
+      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",
+                 potf_name);
     }
-    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2].size()!=coeff_matrix_dim1+3+1){
-      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",potf_name);
+    if (n3b_knot_matrix[temp_type1][temp_type2][temp_type3][2].size() !=
+        coeff_matrix_dim1 + 3 + 1) {
+      error->all(FLERR, "UF3: {} has incorrect knot and coeff data nknots!=ncoeffs + 3 +1",
+                 potf_name);
     }
 
     coeff_matrix_elements_len = coeff_matrix_dim3;
-    
-    key = std::to_string(temp_type1)+std::to_string(temp_type2)+std::to_string(temp_type3); 
+
+    key = std::to_string(temp_type1) + std::to_string(temp_type2) + std::to_string(temp_type3);
     n3b_coeff_matrix[key].resize(coeff_matrix_dim1);
-    for(int i=0;i<coeff_matrix_dim1;i++){
+    for (int i = 0; i < coeff_matrix_dim1; i++) {
       n3b_coeff_matrix[key][i].resize(coeff_matrix_dim2);
-      for(int j=0;j<coeff_matrix_dim2;j++){
+      for (int j = 0; j < coeff_matrix_dim2; j++) {
         temp_line = txtfilereader.next_line(coeff_matrix_elements_len);
         ValueTokenizer coeff_line(temp_line);
         n3b_coeff_matrix[key][i][j].resize(coeff_matrix_dim3);
-        for(int k=0;k<coeff_matrix_dim3;k++) {n3b_coeff_matrix[key][i][j][k] = coeff_line.next_double();}
+        for (int k = 0; k < coeff_matrix_dim3; k++) {
+          n3b_coeff_matrix[key][i][j][k] = coeff_line.next_double();
+        }
       }
     }
-    //if(comm->me==0) utils::logmesg(lmp,"UF3: Finished reading coeff matrix\n");
-    
-    //key = std::to_string(temp_type1)+std::to_string(temp_type3)+std::to_string(temp_type2);
-    //n3b_coeff_matrix[key] = temp_3d_matrix;
+    // if(comm->me==0) utils::logmesg(lmp,"UF3: Finished reading coeff matrix\n");
+
+    // key = std::to_string(temp_type1)+std::to_string(temp_type3)+std::to_string(temp_type2);
+    // n3b_coeff_matrix[key] = temp_3d_matrix;
     /*if(comm->me==0){
     utils::logmesg(lmp,"UF3: coeff_matrix\n");
     for(int i=0;i<coeff_matrix_dim1;i++){
@@ -359,13 +393,18 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
       }
       //utils::logmesg(lmp,"--------------{}\n",i);
     }}*/
-    
-    key = std::to_string(temp_type1)+std::to_string(temp_type3)+std::to_string(temp_type2);
-    n3b_coeff_matrix[key] =  n3b_coeff_matrix[std::to_string(temp_type1)+std::to_string(temp_type2)+std::to_string(temp_type3)];
+
+    key = std::to_string(temp_type1) + std::to_string(temp_type3) + std::to_string(temp_type2);
+    n3b_coeff_matrix[key] =
+        n3b_coeff_matrix[std::to_string(temp_type1) + std::to_string(temp_type2) +
+                         std::to_string(temp_type3)];
     setflag_3b[temp_type1][temp_type2][temp_type3] = 1;
     setflag_3b[temp_type1][temp_type3][temp_type2] = 1;
-  }
-  else error->all(FLERR, "UF3: {} file does not contain right words indicating whether it is 2 or 3 body potential",potf_name);
+  } else
+    error->all(
+        FLERR,
+        "UF3: {} file does not contain right words indicating whether it is 2 or 3 body potential",
+        potf_name);
 }
 
 /* ----------------------------------------------------------------------
@@ -373,8 +412,7 @@ void PairUF3::uf3_read_pot_file(char *potf_name)
 ------------------------------------------------------------------------- */
 void PairUF3::init_style()
 {
-  if (force->newton_pair == 0)
-  error->all(FLERR,"UF3 Pair style requires newton pair on");
+  if (force->newton_pair == 0) error->all(FLERR, "UF3 Pair style requires newton pair on");
   // request a default neighbor list
   neighbor->add_request(this, NeighConst::REQ_FULL);
 }
@@ -391,11 +429,10 @@ void PairUF3::init_list(int /*id*/, class NeighList *ptr)
 /* ----------------------------------------------------------------------
    init for one type pair i,j and corresponding j,i
 ------------------------------------------------------------------------- */
-double PairUF3::init_one(int i/*i*/, int /*j*/j)
+double PairUF3::init_one(int i /*i*/, int /*j*/ j)
 {
-  return sqrt(cutsq[i][j]); 
+  return sqrt(cutsq[i][j]);
 }
-
 
 void PairUF3::compute(int eflag, int vflag)
 {
@@ -407,16 +444,16 @@ void PairUF3::compute(int eflag, int vflag)
   double Fj[3], Fk[3];
   double rsq, rij, rik, rjk;
   int *ilist, *jlist, *klist, *numneigh, **firstneigh;
-  
+
   ev_init(eflag, vflag);
-  
+
   double **x = atom->x;
   double **f = atom->f;
   int *type = atom->type;
   int nlocal = atom->nlocal;
   double *special_lj = force->special_lj;
-  int newton_pair = force->newton_pair;  
-  
+  int newton_pair = force->newton_pair;
+
   inum = list->inum;
   ilist = list->ilist;
   numneigh = list->numneigh;
@@ -438,12 +475,12 @@ void PairUF3::compute(int eflag, int vflag)
       fz = 0;
       j = jlist[jj];
       j &= NEIGHMASK;
-      
-      //delx = x[j][0] - xtmp;
+
+      // delx = x[j][0] - xtmp;
       delx = xtmp - x[j][0];
-      //dely = x[j][1] - ytmp;
+      // dely = x[j][1] - ytmp;
       dely = ytmp - x[j][1];
-      //delz = x[j][2] - ztmp;
+      // delz = x[j][2] - ztmp;
       delz = ztmp - x[j][2];
 
       rsq = delx * delx + dely * dely + delz * delz;
@@ -451,19 +488,19 @@ void PairUF3::compute(int eflag, int vflag)
       if (rsq < cutsq[itype][jtype]) {
         rij = sqrt(rsq);
 
-        if (pot_3b){
-          if (rij<=cut_3b_list[itype][jtype]){
+        if (pot_3b) {
+          if (rij <= cut_3b_list[itype][jtype]) {
             neighshort[numshort] = j;
-            if (numshort >= maxshort-1) {
-              maxshort += maxshort/2;
-              memory->grow(neighshort,maxshort,"pair:neighshort");
+            if (numshort >= maxshort - 1) {
+              maxshort += maxshort / 2;
+              memory->grow(neighshort, maxshort, "pair:neighshort");
             }
             numshort = numshort + 1;
           }
         }
-        
-        fpair = -1*UFBS2b[itype][jtype].bsderivative(rij)/rij;
-        
+
+        fpair = -1 * UFBS2b[itype][jtype].bsderivative(rij) / rij;
+
         fx = delx * fpair;
         fy = dely * fpair;
         fz = delz * fpair;
@@ -478,13 +515,14 @@ void PairUF3::compute(int eflag, int vflag)
         }
         if (eflag) evdwl = UFBS2b[itype][jtype].bsvalue(rij);
 
-        if (evflag) ev_tally_xyz(i, j, nlocal, newton_pair, evdwl, 0.0, fx, fy, fz, delx, dely, delz);
+        if (evflag)
+          ev_tally_xyz(i, j, nlocal, newton_pair, evdwl, 0.0, fx, fy, fz, delx, dely, delz);
       }
     }
-    
-    //3-body interaction
-    //jth atom
-    jnum = numshort - 1; 
+
+    // 3-body interaction
+    // jth atom
+    jnum = numshort - 1;
     for (jj = 0; jj < jnum; jj++) {
       fij[0] = fji[0] = 0;
       fij[1] = fji[1] = 0;
@@ -494,15 +532,16 @@ void PairUF3::compute(int eflag, int vflag)
       del_rji[0] = x[j][0] - xtmp;
       del_rji[1] = x[j][1] - ytmp;
       del_rji[2] = x[j][2] - ztmp;
-      rij = sqrt(((del_rji[0]*del_rji[0])+(del_rji[1]*del_rji[1])+(del_rji[2]*del_rji[2])));
+      rij =
+          sqrt(((del_rji[0] * del_rji[0]) + (del_rji[1] * del_rji[1]) + (del_rji[2] * del_rji[2])));
 
-      //kth atom
-      for(kk = jj+1; kk<numshort; kk++){
-        
+      // kth atom
+      for (kk = jj + 1; kk < numshort; kk++) {
+
         fik[0] = fki[0] = 0;
         fik[1] = fki[1] = 0;
         fik[2] = fki[2] = 0;
-        
+
         fjk[0] = fkj[0] = 0;
         fjk[1] = fkj[1] = 0;
         fjk[2] = fkj[2] = 0;
@@ -512,66 +551,79 @@ void PairUF3::compute(int eflag, int vflag)
         del_rki[0] = x[k][0] - xtmp;
         del_rki[1] = x[k][1] - ytmp;
         del_rki[2] = x[k][2] - ztmp;
-        rik = sqrt(((del_rki[0]*del_rki[0])+(del_rki[1]*del_rki[1])+(del_rki[2]*del_rki[2])));
+        rik = sqrt(
+            ((del_rki[0] * del_rki[0]) + (del_rki[1] * del_rki[1]) + (del_rki[2] * del_rki[2])));
 
-        if ((rij <= cut_3b[itype][jtype][ktype]) && (rik <= cut_3b[itype][ktype][jtype])){
-        
-        del_rkj[0] = x[k][0] - x[j][0];
-        del_rkj[1] = x[k][1] - x[j][1];
-        del_rkj[2] = x[k][2] - x[j][2];
-        rjk = sqrt(((del_rkj[0]*del_rkj[0])+(del_rkj[1]*del_rkj[1])+(del_rkj[2]*del_rkj[2])));
-        
-        ret_val = UFBS3b[itype][jtype][ktype].bsvalue(rij,rik,rjk);
-        ret_val_deri = UFBS3b[itype][jtype][ktype].bsvalue_bsderivative(rij,rik,rjk);
+        if ((rij <= cut_3b[itype][jtype][ktype]) && (rik <= cut_3b[itype][ktype][jtype])) {
 
-        fij[0] = *(ret_val_deri+0)*(del_rji[0]/rij);
-        fji[0] = -fij[0];
-        fik[0] = *(ret_val_deri+1)*(del_rki[0]/rik);
-        fki[0] = -fik[0];
-        fjk[0] = *(ret_val_deri+2)*(del_rkj[0]/rjk);
-        fkj[0] = -fjk[0];
+          del_rkj[0] = x[k][0] - x[j][0];
+          del_rkj[1] = x[k][1] - x[j][1];
+          del_rkj[2] = x[k][2] - x[j][2];
+          rjk = sqrt(
+              ((del_rkj[0] * del_rkj[0]) + (del_rkj[1] * del_rkj[1]) + (del_rkj[2] * del_rkj[2])));
 
-        fij[1] = *(ret_val_deri+0)*(del_rji[1]/rij);
-        fji[1] = -fij[1];
-        fik[1] = *(ret_val_deri+1)*(del_rki[1]/rik);
-        fki[1] = -fik[1];
-        fjk[1] = *(ret_val_deri+2)*(del_rkj[1]/rjk);
-        fkj[1] = -fjk[1];
+          ret_val = UFBS3b[itype][jtype][ktype].bsvalue(rij, rik, rjk);
+          ret_val_deri = UFBS3b[itype][jtype][ktype].bsvalue_bsderivative(rij, rik, rjk);
 
-        fij[2] = *(ret_val_deri+0)*(del_rji[2]/rij);
-        fji[2] = -fij[2];
-        fik[2] = *(ret_val_deri+1)*(del_rki[2]/rik);
-        fki[2] = -fik[2];
-        fjk[2] = *(ret_val_deri+2)*(del_rkj[2]/rjk);
-        fkj[2] = -fjk[2];
-        
-        f[i][0] += fij[0] + fik[0];
-        f[i][1] += fij[1] + fik[1];
-        f[i][2] += fij[2] + fik[2];
+          fij[0] = *(ret_val_deri + 0) * (del_rji[0] / rij);
+          fji[0] = -fij[0];
+          fik[0] = *(ret_val_deri + 1) * (del_rki[0] / rik);
+          fki[0] = -fik[0];
+          fjk[0] = *(ret_val_deri + 2) * (del_rkj[0] / rjk);
+          fkj[0] = -fjk[0];
 
-        f[j][0] += fji[0] + fjk[0];
-        Fj[0]    = fji[0] + fjk[0];
-        f[j][1] += fji[1] + fjk[1];
-        Fj[1]    = fji[1] + fjk[1];
-        f[j][2] += fji[2] + fjk[2];
-        Fj[2]    = fji[2] + fjk[2];
+          fij[1] = *(ret_val_deri + 0) * (del_rji[1] / rij);
+          fji[1] = -fij[1];
+          fik[1] = *(ret_val_deri + 1) * (del_rki[1] / rik);
+          fki[1] = -fik[1];
+          fjk[1] = *(ret_val_deri + 2) * (del_rkj[1] / rjk);
+          fkj[1] = -fjk[1];
 
-        f[k][0] += fki[0] + fkj[0];
-        Fk[0]    = fki[0] + fkj[0];
-        f[k][1] += fki[1] + fkj[1];
-        Fk[1]    = fki[1] + fkj[1];
-        f[k][2] += fki[2] + fkj[2];
-        Fk[2]    = fki[2] + fkj[2];
+          fij[2] = *(ret_val_deri + 0) * (del_rji[2] / rij);
+          fji[2] = -fij[2];
+          fik[2] = *(ret_val_deri + 1) * (del_rki[2] / rik);
+          fki[2] = -fik[2];
+          fjk[2] = *(ret_val_deri + 2) * (del_rkj[2] / rjk);
+          fkj[2] = -fjk[2];
 
-        if (eflag) evdwl = ret_val; // 2/3 because of ev_tally_xyz
+          f[i][0] += fij[0] + fik[0];
+          f[i][1] += fij[1] + fik[1];
+          f[i][2] += fij[2] + fik[2];
 
-        if (evflag) {
-          ev_tally3(i,j,k, evdwl, 0, Fj, Fk, del_rji, del_rki);
+          f[j][0] += fji[0] + fjk[0];
+          Fj[0] = fji[0] + fjk[0];
+          f[j][1] += fji[1] + fjk[1];
+          Fj[1] = fji[1] + fjk[1];
+          f[j][2] += fji[2] + fjk[2];
+          Fj[2] = fji[2] + fjk[2];
+
+          f[k][0] += fki[0] + fkj[0];
+          Fk[0] = fki[0] + fkj[0];
+          f[k][1] += fki[1] + fkj[1];
+          Fk[1] = fki[1] + fkj[1];
+          f[k][2] += fki[2] + fkj[2];
+          Fk[2] = fki[2] + fkj[2];
+
+          if (eflag) evdwl = ret_val;    // 2/3 because of ev_tally_xyz
+
+          if (evflag) { ev_tally3(i, j, k, evdwl, 0, Fj, Fk, del_rji, del_rki); }
         }
       }
-      }
-    } 
+    }
   }
   if (vflag_fdotr) virial_fdotr_compute();
 }
 
+double PairUF3::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
+                       double /*factor_coul*/, double factor_lj, double &fforce)
+{
+  double value = 0.0;
+  double r = sqrt(rsq);
+
+  if (r < cutsq[itype][jtype]) {
+    value = UFBS2b[itype][jtype].bsvalue(r);
+    fforce = factor_lj * UFBS2b[itype][jtype].bsderivative(r);
+  }
+
+  return factor_lj * value;
+}

--- a/lammps_plugin/ML-UF3/pair_uf3.h
+++ b/lammps_plugin/ML-UF3/pair_uf3.h
@@ -11,6 +11,12 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+ *    Contributing authors: Ajinkya Hire(U of Florida), 
+ *                          Hendrik Kraß (U of Constance),
+ *                          Richard Hennig (U of Florida)
+ * ---------------------------------------------------------------------- */
+
 #ifdef PAIR_CLASS
 // clang-format off
 PairStyle(uf3,PairUF3);
@@ -35,30 +41,25 @@ class PairUF3 : public Pair {
   void compute(int, int) override;
   void settings(int, char **) override;
   void coeff(int, char **) override;
-  void uf3_read_pot_file(char *potf_name);
   void init_style() override;
   void init_list(int, class NeighList *) override;    // needed for ptr to full neigh list
   double init_one(int, int) override;                 // needed for cutoff radius for neighbour list
   double single(int, int, int, int, double, double, double, double &) override;
 
  protected:
+  void uf3_read_pot_file(char *potf_name);
   int num_of_elements, nbody_flag, n2body_pot_files, n3body_pot_files, tot_pot_files;
-  int temp_type1, temp_type2, temp_type3, temp_line_len;
   int coeff_matrix_dim1, coeff_matrix_dim2, coeff_matrix_dim3, coeff_matrix_elements_len;
   bool pot_3b;
   int ***setflag_3b;
-  double **cutsq_2b, ***cut_3b, **cut_3b_list, cut3b_rjk, cut3b_rij, cut3b_rik;
+  double ***cut_3b, **cut_3b_list;
   virtual void allocate();
   std::vector<std::vector<std::vector<double>>> n2b_knot, n2b_coeff;
   std::vector<std::vector<std::vector<std::vector<std::vector<double>>>>> n3b_knot_matrix;
-  std::vector<std::vector<std::vector<double>>> temp_3d_matrix;
   std::unordered_map<std::string, std::vector<std::vector<std::vector<double>>>> n3b_coeff_matrix;
-  std::string key;
   std::vector<std::vector<uf3_pair_bspline>> UFBS2b;
   std::vector<std::vector<std::vector<uf3_triplet_bspline>>> UFBS3b;
   int *neighshort, maxshort;    // short neighbor list array for 3body interaction
-  double ret_val;
-  double *ret_val_deri;
 };
 
 }    // namespace LAMMPS_NS

--- a/lammps_plugin/ML-UF3/pair_uf3.h
+++ b/lammps_plugin/ML-UF3/pair_uf3.h
@@ -37,9 +37,9 @@ class PairUF3 : public Pair {
   void coeff(int, char **) override;
   void uf3_read_pot_file(char *potf_name);
   void init_style() override;
-  void init_list(int, class NeighList *) override; //needed for ptr to full neigh list
-  double init_one(int, int) override; //needed for cutoff radius for neighbour list
-  
+  void init_list(int, class NeighList *) override;    // needed for ptr to full neigh list
+  double init_one(int, int) override;                 // needed for cutoff radius for neighbour list
+  double single(int, int, int, int, double, double, double, double &) override;
 
  protected:
   int num_of_elements, nbody_flag, n2body_pot_files, n3body_pot_files, tot_pot_files;
@@ -58,7 +58,7 @@ class PairUF3 : public Pair {
   std::vector<std::vector<std::vector<uf3_triplet_bspline>>> UFBS3b;
   int *neighshort, maxshort;    // short neighbor list array for 3body interaction
   double ret_val;
-  double * ret_val_deri; 
+  double *ret_val_deri;
 };
 
 }    // namespace LAMMPS_NS

--- a/lammps_plugin/ML-UF3/uf3_bspline_basis2.cpp
+++ b/lammps_plugin/ML-UF3/uf3_bspline_basis2.cpp
@@ -1,0 +1,79 @@
+#include "uf3_bspline_basis2.h"
+
+#include "utils.h"
+#include <vector>
+
+using namespace LAMMPS_NS;
+
+// Constructor
+// Initializes coefficients and knots
+// Requires [knots] to have length 4
+uf3_bspline_basis2::uf3_bspline_basis2(LAMMPS *ulmp, const double *knots, double coefficient)
+{
+  lmp = ulmp;
+
+  double c0, c1, c2;
+
+  c0 = coefficient *
+      (pow(knots[0], 2) /
+       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+  c1 = coefficient *
+      (-2 * knots[0] /
+       (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+  c2 = coefficient *
+      (1 / (pow(knots[0], 2) - knots[0] * knots[1] - knots[0] * knots[2] + knots[1] * knots[2]));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  c0 = coefficient *
+      (-knots[1] * knots[3] /
+           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+       knots[0] * knots[2] /
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+  c1 = coefficient *
+      (knots[1] /
+           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+       knots[3] /
+           (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) +
+       knots[0] /
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)) +
+       knots[2] /
+           (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+  c2 = coefficient *
+      (-1 / (pow(knots[1], 2) - knots[1] * knots[2] - knots[1] * knots[3] + knots[2] * knots[3]) -
+       1 / (knots[0] * knots[1] - knots[0] * knots[2] - knots[1] * knots[2] + pow(knots[2], 2)));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  c0 = coefficient *
+      (pow(knots[3], 2) /
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+  c1 = coefficient *
+      (-2 * knots[3] /
+       (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+  c2 = coefficient *
+      (1 / (knots[1] * knots[2] - knots[1] * knots[3] - knots[2] * knots[3] + pow(knots[3], 2)));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+}
+
+uf3_bspline_basis2::~uf3_bspline_basis2() {}
+
+// Evaluate outer-left part of spline
+double uf3_bspline_basis2::eval0(double rsq, double r)
+{
+  return rsq * constants[2] + r * constants[1] + constants[0];
+}
+
+// Evaluate center-left part of spline
+double uf3_bspline_basis2::eval1(double rsq, double r)
+{
+  return rsq * constants[5] + r * constants[4] + constants[3];
+}
+
+// Evaluate center-right part of spline
+double uf3_bspline_basis2::eval2(double rsq, double r)
+{
+  return rsq * constants[8] + r * constants[7] + constants[6];
+}

--- a/lammps_plugin/ML-UF3/uf3_bspline_basis2.h
+++ b/lammps_plugin/ML-UF3/uf3_bspline_basis2.h
@@ -1,0 +1,30 @@
+//De Boor's algorithm @
+//https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/de-Boor.html
+//For values outside the domain,
+//extrapoltaes the left(right) hand side piece of the curve
+//Only works for bspline degree upto 3 becuase of definiation of P
+//
+#include "pointers.h"
+
+#include <vector>
+
+#ifndef UF3_BSPLINE_BASIS2_H
+#define UF3_BSPLINE_BASIS2_H
+
+namespace LAMMPS_NS {
+
+class uf3_bspline_basis2 {
+ private:
+  LAMMPS *lmp;
+  std::vector<double> constants;
+
+ public:
+  uf3_bspline_basis2(LAMMPS *ulmp, const double *knots, double coefficient);
+  ~uf3_bspline_basis2();
+  double eval0(double, double);
+  double eval1(double, double);
+  double eval2(double, double);
+};
+
+}    // namespace LAMMPS_NS
+#endif

--- a/lammps_plugin/ML-UF3/uf3_bspline_basis3.cpp
+++ b/lammps_plugin/ML-UF3/uf3_bspline_basis3.cpp
@@ -1,0 +1,315 @@
+#include "uf3_bspline_basis3.h"
+
+#include "utils.h"
+#include <vector>
+
+using namespace LAMMPS_NS;
+
+// Constructor
+// Initializes coefficients and knots
+// [knots] needs to have length 4
+uf3_bspline_basis3::uf3_bspline_basis3(LAMMPS *ulmp, const double *knots, double coefficient)
+{
+  lmp = ulmp;
+
+  double c0, c1, c2, c3;
+
+  c0 = coefficient *
+      (-pow(knots[0], 3) /
+       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+        knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+        knots[1] * knots[2] * knots[3]));
+  c1 = coefficient *
+      (3 * pow(knots[0], 2) /
+       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+        knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+        knots[1] * knots[2] * knots[3]));
+  c2 = coefficient *
+      (-3 * knots[0] /
+       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+        knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+        knots[1] * knots[2] * knots[3]));
+  c3 = coefficient *
+      (1 /
+       (-pow(knots[0], 3) + pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+        pow(knots[0], 2) * knots[3] - knots[0] * knots[1] * knots[2] -
+        knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+        knots[1] * knots[2] * knots[3]));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  constants.push_back(c3);
+  c0 = coefficient *
+      (pow(knots[1], 2) * knots[4] /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) +
+       pow(knots[0], 2) * knots[2] /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+       knots[0] * knots[1] * knots[3] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+  c1 = coefficient *
+      (-pow(knots[1], 2) /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) -
+       2 * knots[1] * knots[4] /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) -
+       pow(knots[0], 2) /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+       2 * knots[0] * knots[2] /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+       knots[0] * knots[1] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+       knots[0] * knots[3] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) -
+       knots[1] * knots[3] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+  c2 = coefficient *
+      (2 * knots[1] /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) +
+       knots[4] /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) +
+       2 * knots[0] /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+       knots[2] /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) +
+       knots[0] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+       knots[1] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)) +
+       knots[3] /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+  c3 = coefficient *
+      (-1 /
+           (-pow(knots[1], 3) + pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            pow(knots[1], 2) * knots[4] - knots[1] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            knots[2] * knots[3] * knots[4]) -
+       1 /
+           (-pow(knots[0], 2) * knots[1] + pow(knots[0], 2) * knots[2] +
+            knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] -
+            knots[0] * pow(knots[2], 2) - knots[0] * knots[2] * knots[3] -
+            knots[1] * knots[2] * knots[3] + pow(knots[2], 2) * knots[3]) -
+       1 /
+           (-knots[0] * pow(knots[1], 2) + knots[0] * knots[1] * knots[2] +
+            knots[0] * knots[1] * knots[3] - knots[0] * knots[2] * knots[3] +
+            pow(knots[1], 2) * knots[3] - knots[1] * knots[2] * knots[3] -
+            knots[1] * pow(knots[3], 2) + knots[2] * pow(knots[3], 2)));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  constants.push_back(c3);
+  c0 = coefficient *
+      (-knots[0] * pow(knots[3], 2) /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+       knots[1] * knots[3] * knots[4] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+       knots[2] * pow(knots[4], 2) /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+  c1 = coefficient *
+      (2 * knots[0] * knots[3] /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+       pow(knots[3], 2) /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+       knots[1] * knots[3] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+       knots[1] * knots[4] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+       knots[3] * knots[4] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+       2 * knots[2] * knots[4] /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) +
+       pow(knots[4], 2) /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+  c2 = coefficient *
+      (-knots[0] /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+       2 * knots[3] /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) -
+       knots[1] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+       knots[3] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+       knots[4] /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) -
+       knots[2] /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)) -
+       2 * knots[4] /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+  c3 = coefficient *
+      (1 /
+           (-knots[0] * knots[1] * knots[2] + knots[0] * knots[1] * knots[3] +
+            knots[0] * knots[2] * knots[3] - knots[0] * pow(knots[3], 2) +
+            knots[1] * knots[2] * knots[3] - knots[1] * pow(knots[3], 2) -
+            knots[2] * pow(knots[3], 2) + pow(knots[3], 3)) +
+       1 /
+           (-pow(knots[1], 2) * knots[2] + pow(knots[1], 2) * knots[3] +
+            knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] -
+            knots[1] * pow(knots[3], 2) - knots[1] * knots[3] * knots[4] -
+            knots[2] * knots[3] * knots[4] + pow(knots[3], 2) * knots[4]) +
+       1 /
+           (-knots[1] * pow(knots[2], 2) + knots[1] * knots[2] * knots[3] +
+            knots[1] * knots[2] * knots[4] - knots[1] * knots[3] * knots[4] +
+            pow(knots[2], 2) * knots[4] - knots[2] * knots[3] * knots[4] -
+            knots[2] * pow(knots[4], 2) + knots[3] * pow(knots[4], 2)));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  constants.push_back(c3);
+  c0 = coefficient *
+      (pow(knots[4], 3) /
+       (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
+        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
+        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
+        pow(knots[4], 3)));
+  c1 = coefficient *
+      (-3 * pow(knots[4], 2) /
+       (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
+        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
+        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
+        pow(knots[4], 3)));
+  c2 = coefficient *
+      (3 * knots[4] /
+       (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
+        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
+        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
+        pow(knots[4], 3)));
+  c3 = coefficient *
+      (-1 /
+       (-knots[1] * knots[2] * knots[3] + knots[1] * knots[2] * knots[4] +
+        knots[1] * knots[3] * knots[4] - knots[1] * pow(knots[4], 2) +
+        knots[2] * knots[3] * knots[4] - knots[2] * pow(knots[4], 2) - knots[3] * pow(knots[4], 2) +
+        pow(knots[4], 3)));
+  constants.push_back(c0);
+  constants.push_back(c1);
+  constants.push_back(c2);
+  constants.push_back(c3);
+}
+
+uf3_bspline_basis3::~uf3_bspline_basis3() {}
+
+// Evaluate outer-left part of spline
+double uf3_bspline_basis3::eval0(double rth, double rsq, double r)
+{
+  return rth * constants[3] + rsq * constants[2] + r * constants[1] + constants[0];
+}
+
+// Evaluate center-left part of spline
+double uf3_bspline_basis3::eval1(double rth, double rsq, double r)
+{
+  return rth * constants[7] + rsq * constants[6] + r * constants[5] + constants[4];
+}
+
+// Evaluate center-right part of spline
+double uf3_bspline_basis3::eval2(double rth, double rsq, double r)
+{
+  return rth * constants[11] + rsq * constants[10] + r * constants[9] + constants[8];
+}
+
+// Evaluate outer-right part of spline
+double uf3_bspline_basis3::eval3(double rth, double rsq, double r)
+{
+  return rth * constants[15] + rsq * constants[14] + r * constants[13] + constants[12];
+}

--- a/lammps_plugin/ML-UF3/uf3_bspline_basis3.h
+++ b/lammps_plugin/ML-UF3/uf3_bspline_basis3.h
@@ -1,0 +1,31 @@
+//De Boor's algorithm @
+//https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/de-Boor.html
+//For values outside the domain,
+//extrapoltaes the left(right) hand side piece of the curve
+//Only works for bspline degree upto 3 becuase of definiation of P
+//
+#include "pointers.h"
+
+#include <vector>
+
+#ifndef UF3_BSPLINE_BASIS3_H
+#define UF3_BSPLINE_BASIS3_H
+
+namespace LAMMPS_NS {
+
+class uf3_bspline_basis3 {
+ private:
+  LAMMPS *lmp;
+  std::vector<double> constants;
+
+ public:
+  uf3_bspline_basis3(LAMMPS *ulmp, const double *knots, double coefficient);
+  ~uf3_bspline_basis3();
+  double eval0(double, double, double);
+  double eval1(double, double, double);
+  double eval2(double, double, double);
+  double eval3(double, double, double);
+};
+
+}    // namespace LAMMPS_NS
+#endif

--- a/lammps_plugin/ML-UF3/uf3_pair_bspline.cpp
+++ b/lammps_plugin/ML-UF3/uf3_pair_bspline.cpp
@@ -7,124 +7,624 @@ using namespace LAMMPS_NS;
 
 //Call constructor
 //Dummy constructor
-uf3_pair_bspline::uf3_pair_bspline(){}
+uf3_pair_bspline::uf3_pair_bspline() {}
 //Constructor
-//passing vect by reference 
-uf3_pair_bspline::uf3_pair_bspline(LAMMPS* ulmp, int ubspline_degree,
-				const std::vector<double> &uknot_vect, const std::vector<double> &ucoeff_vect){
-	lmp = ulmp;
-	bspline_degree = ubspline_degree;
-	knot_vect = uknot_vect;
-	coeff_vect = ucoeff_vect;
-	knot_vect_size = uknot_vect.size();
-	coeff_vect_size = ucoeff_vect.size();
-	//initialize dncoeff_vect and dnknot_coeff for derivates
-	for (int i=0;i<coeff_vect_size-1;++i){
-		dntemp4 = bspline_degree/(knot_vect[i+bspline_degree+1]-knot_vect[i+1]);
-		dncoeff_vect.push_back((coeff_vect[i+1]-coeff_vect[i])*dntemp4);
-	}
-	for (int i=1;i<knot_vect_size-1;++i){
-		dnknot_vect.push_back(knot_vect[i]);
-	}
+//passing vect by reference
+uf3_pair_bspline::uf3_pair_bspline(LAMMPS *ulmp, int ubspline_degree,
+                                   const std::vector<double> &uknot_vect,
+                                   const std::vector<double> &ucoeff_vect)
+{
+  lmp = ulmp;
+  bspline_degree = ubspline_degree;
+  knot_vect = uknot_vect;
+  coeff_vect = ucoeff_vect;
+
+  knot_vect_size = uknot_vect.size();
+  coeff_vect_size = ucoeff_vect.size();
+  //initialize dncoeff_vect and dnknot_coeff for derivates
+  for (int i = 0; i < coeff_vect_size - 1; ++i) {
+    dntemp4 = bspline_degree / (knot_vect[i + bspline_degree + 1] - knot_vect[i + 1]);
+    dncoeff_vect.push_back((coeff_vect[i + 1] - coeff_vect[i]) * dntemp4);
+  }
+  for (int i = 1; i < knot_vect_size - 1; ++i) { dnknot_vect.push_back(knot_vect[i]); }
+
+  // Cache constants
+  double c0, c1, c2, c3;
+  for (int i = 0; i < knot_vect.size() - 4; i++) {
+    std::vector<double> row;
+
+    c0 = coeff_vect[i] *
+        (-pow(knot_vect[i + 0], 3) /
+         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
+    c1 = coeff_vect[i] *
+        (3 * pow(knot_vect[i + 0], 2) /
+         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
+    c2 = coeff_vect[i] *
+        (-3 * knot_vect[i + 0] /
+         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
+    c3 = coeff_vect[i] *
+        (1 /
+         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
+          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    row.push_back(c3);
+    c0 = coeff_vect[i] *
+        (pow(knot_vect[i + 1], 2) * knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
+         pow(knot_vect[i + 0], 2) * knot_vect[i + 2] /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
+         knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
+    c1 = coeff_vect[i] *
+        (-pow(knot_vect[i + 1], 2) /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
+         2 * knot_vect[i + 1] * knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
+         pow(knot_vect[i + 0], 2) /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
+         2 * knot_vect[i + 0] * knot_vect[i + 2] /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
+         knot_vect[i + 0] * knot_vect[i + 1] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) -
+         knot_vect[i + 0] * knot_vect[i + 3] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) -
+         knot_vect[i + 1] * knot_vect[i + 3] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
+    c2 = coeff_vect[i] *
+        (2 * knot_vect[i + 1] /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
+         knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
+         2 * knot_vect[i + 0] /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
+         knot_vect[i + 2] /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
+         knot_vect[i + 0] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) +
+         knot_vect[i + 1] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) +
+         knot_vect[i + 3] /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
+    c3 = coeff_vect[i] *
+        (-1 /
+             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
+         1 /
+             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
+              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
+         1 /
+             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    row.push_back(c3);
+    c0 = coeff_vect[i] *
+        (-knot_vect[i + 0] * pow(knot_vect[i + 3], 2) /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
+         knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
+         knot_vect[i + 2] * pow(knot_vect[i + 4], 2) /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
+    c1 = coeff_vect[i] *
+        (2 * knot_vect[i + 0] * knot_vect[i + 3] /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
+         pow(knot_vect[i + 3], 2) /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
+         knot_vect[i + 1] * knot_vect[i + 3] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
+         knot_vect[i + 1] * knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
+         knot_vect[i + 3] * knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
+         2 * knot_vect[i + 2] * knot_vect[i + 4] /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)) +
+         pow(knot_vect[i + 4], 2) /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
+    c2 = coeff_vect[i] *
+        (-knot_vect[i + 0] /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
+         2 * knot_vect[i + 3] /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
+         knot_vect[i + 1] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
+         knot_vect[i + 3] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
+         knot_vect[i + 4] /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
+         knot_vect[i + 2] /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)) -
+         2 * knot_vect[i + 4] /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
+    c3 = coeff_vect[i] *
+        (1 /
+             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
+              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
+              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
+         1 /
+             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
+              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
+         1 /
+             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
+              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
+              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
+              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
+              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
+
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    row.push_back(c3);
+    c0 = coeff_vect[i] *
+        (pow(knot_vect[i + 4], 3) /
+         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
+          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
+          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
+          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
+    c1 = coeff_vect[i] *
+        (-3 * pow(knot_vect[i + 4], 2) /
+         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
+          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
+          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
+          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
+    c2 = coeff_vect[i] *
+        (3 * knot_vect[i + 4] /
+         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
+          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
+          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
+          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
+    c3 = coeff_vect[i] *
+        (-1 /
+         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
+          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
+          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
+          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
+          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
+          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    row.push_back(c3);
+    constants.push_back(row);
+  }
+
+  // Cache derivative constants
+
+  for (int i = 0; i < dnknot_vect.size() - 3; i++) {
+    std::vector<double> row;
+    c0 = dncoeff_vect[i] *
+        (pow(dnknot_vect[i + 0], 2) /
+         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
+          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
+    c1 = dncoeff_vect[i] *
+        (-2 * dnknot_vect[i + 0] /
+         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
+          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
+    c2 = dncoeff_vect[i] *
+        (1 /
+         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
+          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    c0 = dncoeff_vect[i] *
+        (-dnknot_vect[i + 1] * dnknot_vect[i + 3] /
+             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) -
+         dnknot_vect[i + 0] * dnknot_vect[i + 2] /
+             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
+    c1 = dncoeff_vect[i] *
+        (dnknot_vect[i + 1] /
+             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) +
+         dnknot_vect[i + 3] /
+             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) +
+         dnknot_vect[i + 0] /
+             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)) +
+         dnknot_vect[i + 2] /
+             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
+    c2 = dncoeff_vect[i] *
+        (-1 /
+             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) -
+         1 /
+             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
+              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    c0 = dncoeff_vect[i] *
+        (pow(dnknot_vect[i + 3], 2) /
+         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
+          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
+    c1 = dncoeff_vect[i] *
+        (-2 * dnknot_vect[i + 3] /
+         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
+          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
+    c2 = dncoeff_vect[i] *
+        (1 /
+         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
+          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
+    row.push_back(c0);
+    row.push_back(c1);
+    row.push_back(c2);
+    dconstants.push_back(row);
+  }
 }
 
-uf3_pair_bspline::~uf3_pair_bspline(){}
+uf3_pair_bspline::~uf3_pair_bspline() {}
 
 //value function definition
 //input -->rij; output -->value on the bspline curve
 double uf3_pair_bspline::bsvalue(double value_rij)
 {
-	//utils::logmesg(lmp,"return this value {}",this->uf3_pair_bspline::main_eval_loop(value_rij,bspline_degree,knot_vect,
-        //                                                coeff_vect));
-	return this->uf3_pair_bspline::main_eval_loop(value_rij,bspline_degree,knot_vect,
-							coeff_vect);
+  //utils::logmesg(lmp,"return this value {}",this->uf3_pair_bspline::main_eval_loop(value_rij,bspline_degree,knot_vect,
+  //                                                coeff_vect));
+  return this->uf3_pair_bspline::main_eval_loop(value_rij, bspline_degree, knot_vect, coeff_vect);
 }
 
 double uf3_pair_bspline::bsderivative(double value_rij)
 {
-	if (bspline_degree < 1){
-		return 0;}
-	else{
-		return this->uf3_pair_bspline::main_eval_loop(value_rij,bspline_degree-1,dnknot_vect,
-								dncoeff_vect);}
+  if (bspline_degree < 1) {
+    return 0;
+  } else {
+    return this->uf3_pair_bspline::main_eval_loop(value_rij, bspline_degree - 1, dnknot_vect,
+                                                  dncoeff_vect);
+  }
 }
 
+double uf3_pair_bspline::main_eval_loop(double r, int ibspline_degree,
+                                        const std::vector<double> &iknot_vect,
+                                        const std::vector<double> &icoeff_vect)
+{
+  int ipos_i = 0;
+  int iknot_mult = 0;
+  h = 0;
+  max_count = 0;
+  knot_affect_start = 0;
+  knot_affect_end = 0;
+  temp2 = 0;
+  temp3 = 0;
+  temp_val = 0;
+  if (iknot_vect.front() <= r && r < iknot_vect.back()) {
+    //Determine the interval for value_rij
+    for (int i = 0; i < knot_vect_size - 1; ++i) {
+      if (iknot_vect[i] <= r && r < iknot_vect[i + 1]) {
+        ipos_i = i;
+        break;
+      }
+    }
+  }
+  //#---------------------
+  //#----main eval loop---
+  //#---------------------
+  knot_affect_start = ipos_i - ibspline_degree;
 
-double uf3_pair_bspline::main_eval_loop(double ivalue_rij, int ibspline_degree,
-					const std::vector<double> &iknot_vect,
-					const std::vector<double> &icoeff_vect){
-	int ipos_i = 0;
-	int iknot_mult = 0;
-	h = 0; max_count = 0; knot_affect_start = 0; knot_affect_end = 0;
-	temp2 = 0; temp3 = 0;
-	temp_val = 0;
-	if (iknot_vect.front() <= ivalue_rij && ivalue_rij < iknot_vect.back()){
-		//Determine the interval for value_rij
-		for (int i=0; i<knot_vect_size-1; ++i){
-			if (iknot_vect[i] <= ivalue_rij && ivalue_rij < iknot_vect[i+1])
-				{ipos_i = i; break;}
-		}
-		//if value_rij is equal to existing knot then
-		//determine multiplicity of existing knot
-		if (ivalue_rij==iknot_vect[ipos_i]){
-			for (int i=0;i<knot_vect_size;++i){
-				if (iknot_vect[i]==ivalue_rij){
-					iknot_mult = iknot_mult + 1;
-				}
-				else if (ivalue_rij<iknot_vect[i]){break;}
-				else {}
-			}
-		}
-	}
-	//Extrapolating outside the domain?
-	//--value_rij on the left hand side
-	else if (ivalue_rij < iknot_vect[0]){
-		for (int i=0; i < knot_vect_size-1; ++i){
-			if (iknot_vect[i] != iknot_vect[i+1])
-				{ipos_i = i; break;}
-		}
-	}
-	//--value_rij on the right hand side
-	else
-	{
-		for (int i=knot_vect_size-1;i>0;--i){
-			if (iknot_vect[i] != iknot_vect[i-1])
-				{ipos_i = i-1; break;}
-		}
-	}
-	//#---------------------
-	//#----main eval loop---
-	//#---------------------
-	h = ibspline_degree - iknot_mult;
-	//value_rij = existing knots and the knot_mult > bspline_dgree
-	if (h==-1){
-		temp_val = icoeff_vect[ipos_i-ibspline_degree];
-		return temp_val;
-	}
-	else{
-		knot_affect_start = ipos_i - ibspline_degree;
-		knot_affect_end = ipos_i - iknot_mult;
-		//set knot affect start(end) = 0 if < 0; can happen
-		//if value_rij is close to the left hand side of the domain
-		if (knot_affect_start <0)
-			{knot_affect_start = 0;}
-		if (knot_affect_end < knot_affect_start)
-			{knot_affect_end =knot_affect_start;}
-		
-		max_count = knot_affect_end + 1 - knot_affect_start;
-		//P[3][3] = {0};
-		//Set the 0th affected Coeffn
-		for (int i=0; i< max_count; ++i)
-			{P[0][i] = icoeff_vect[i+knot_affect_start];}
-		
-		for (int r=1; r<h+1;++r){
-			for (int i=ipos_i-ibspline_degree+r; i <ipos_i-iknot_mult+1; ++i){
-				temp2 = i+ibspline_degree-r+1;
-				temp3 = (ivalue_rij-iknot_vect[i])/(iknot_vect[temp2]-iknot_vect[i]);
-				P[r][i-knot_affect_start] = ((1-temp3)*P[r-1][i-knot_affect_start-1]) + (temp3*P[r-1][i-knot_affect_start]);
-			}
-		}
-		temp_val = P[ibspline_degree-iknot_mult][ipos_i-iknot_mult-knot_affect_start];
-		return temp_val;
-	}
+  double rsq = r * r;
+  double rth = rsq * r;
+
+  if (ibspline_degree == 3) {
+    temp_val = rth * constants[knot_affect_start + 3][3] +
+        rsq * constants[knot_affect_start + 3][2] + r * constants[knot_affect_start + 3][1] +
+        constants[knot_affect_start + 3][0];
+    temp_val += rth * constants[knot_affect_start + 2][7] +
+        rsq * constants[knot_affect_start + 2][6] + r * constants[knot_affect_start + 2][5] +
+        constants[knot_affect_start + 2][4];
+    temp_val += rth * constants[knot_affect_start + 1][11] +
+        rsq * constants[knot_affect_start + 1][10] + r * constants[knot_affect_start + 1][9] +
+        constants[knot_affect_start + 1][8];
+    temp_val += rth * constants[knot_affect_start + 0][15] +
+        rsq * constants[knot_affect_start + 0][14] + r * constants[knot_affect_start + 0][13] +
+        constants[knot_affect_start + 0][12];
+    return temp_val;
+  }
+
+  else if (ibspline_degree == 2) {
+    temp_val = rsq * dconstants[knot_affect_start + 2][2] +
+        r * dconstants[knot_affect_start + 2][1] + dconstants[knot_affect_start + 2][0];
+    temp_val += rsq * dconstants[knot_affect_start + 1][5] +
+        r * dconstants[knot_affect_start + 1][4] + dconstants[knot_affect_start + 1][3];
+    temp_val += rsq * dconstants[knot_affect_start + 0][8] +
+        r * dconstants[knot_affect_start + 0][7] + dconstants[knot_affect_start + 0][6];
+    return temp_val;
+  }
+
+  return 0;
 }

--- a/lammps_plugin/ML-UF3/uf3_pair_bspline.cpp
+++ b/lammps_plugin/ML-UF3/uf3_pair_bspline.cpp
@@ -1,630 +1,79 @@
 #include "uf3_pair_bspline.h"
 
+#include "uf3_bspline_basis2.h"
+#include "uf3_bspline_basis3.h"
+
 #include "utils.h"
 #include <vector>
 
 using namespace LAMMPS_NS;
 
-//Call constructor
-//Dummy constructor
+// Dummy constructor
 uf3_pair_bspline::uf3_pair_bspline() {}
-//Constructor
-//passing vect by reference
-uf3_pair_bspline::uf3_pair_bspline(LAMMPS *ulmp, int ubspline_degree,
-                                   const std::vector<double> &uknot_vect,
+
+// Constructor
+// Passing vectors by reference
+uf3_pair_bspline::uf3_pair_bspline(LAMMPS *ulmp, const std::vector<double> &uknot_vect,
                                    const std::vector<double> &ucoeff_vect)
 {
   lmp = ulmp;
-  bspline_degree = ubspline_degree;
   knot_vect = uknot_vect;
   coeff_vect = ucoeff_vect;
 
   knot_vect_size = uknot_vect.size();
   coeff_vect_size = ucoeff_vect.size();
-  //initialize dncoeff_vect and dnknot_coeff for derivates
-  for (int i = 0; i < coeff_vect_size - 1; ++i) {
-    dntemp4 = bspline_degree / (knot_vect[i + bspline_degree + 1] - knot_vect[i + 1]);
+
+  // Initialize B-Spline Basis Functions
+  for (int i = 0; i < knot_vect.size() - 4; i++)
+    bspline_bases.push_back(uf3_bspline_basis3(lmp, &knot_vect[i], coeff_vect[i]));
+
+  // Initialize Coefficients and Knots for Derivatives
+  for (int i = 0; i < coeff_vect_size - 1; i++) {
+    double dntemp4 = 3 / (knot_vect[i + 4] - knot_vect[i + 1]);
     dncoeff_vect.push_back((coeff_vect[i + 1] - coeff_vect[i]) * dntemp4);
   }
-  for (int i = 1; i < knot_vect_size - 1; ++i) { dnknot_vect.push_back(knot_vect[i]); }
+  for (int i = 1; i < knot_vect_size - 1; i++) dnknot_vect.push_back(knot_vect[i]);
 
-  // Cache constants
-  double c0, c1, c2, c3;
-  for (int i = 0; i < knot_vect.size() - 4; i++) {
-    std::vector<double> row;
-
-    c0 = coeff_vect[i] *
-        (-pow(knot_vect[i + 0], 3) /
-         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
-    c1 = coeff_vect[i] *
-        (3 * pow(knot_vect[i + 0], 2) /
-         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
-    c2 = coeff_vect[i] *
-        (-3 * knot_vect[i + 0] /
-         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
-    c3 = coeff_vect[i] *
-        (1 /
-         (-pow(knot_vect[i + 0], 3) + pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-          pow(knot_vect[i + 0], 2) * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] -
-          knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-          knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3]));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    row.push_back(c3);
-    c0 = coeff_vect[i] *
-        (pow(knot_vect[i + 1], 2) * knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
-         pow(knot_vect[i + 0], 2) * knot_vect[i + 2] /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
-         knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
-    c1 = coeff_vect[i] *
-        (-pow(knot_vect[i + 1], 2) /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
-         2 * knot_vect[i + 1] * knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
-         pow(knot_vect[i + 0], 2) /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
-         2 * knot_vect[i + 0] * knot_vect[i + 2] /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
-         knot_vect[i + 0] * knot_vect[i + 1] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) -
-         knot_vect[i + 0] * knot_vect[i + 3] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) -
-         knot_vect[i + 1] * knot_vect[i + 3] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
-    c2 = coeff_vect[i] *
-        (2 * knot_vect[i + 1] /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
-         knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) +
-         2 * knot_vect[i + 0] /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
-         knot_vect[i + 2] /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) +
-         knot_vect[i + 0] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) +
-         knot_vect[i + 1] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)) +
-         knot_vect[i + 3] /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
-    c3 = coeff_vect[i] *
-        (-1 /
-             (-pow(knot_vect[i + 1], 3) + pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4]) -
-         1 /
-             (-pow(knot_vect[i + 0], 2) * knot_vect[i + 1] +
-              pow(knot_vect[i + 0], 2) * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 2], 2) -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 3]) -
-         1 /
-             (-knot_vect[i + 0] * pow(knot_vect[i + 1], 2) +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] -
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] -
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2)));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    row.push_back(c3);
-    c0 = coeff_vect[i] *
-        (-knot_vect[i + 0] * pow(knot_vect[i + 3], 2) /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
-         knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
-         knot_vect[i + 2] * pow(knot_vect[i + 4], 2) /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
-    c1 = coeff_vect[i] *
-        (2 * knot_vect[i + 0] * knot_vect[i + 3] /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
-         pow(knot_vect[i + 3], 2) /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
-         knot_vect[i + 1] * knot_vect[i + 3] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
-         knot_vect[i + 1] * knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
-         knot_vect[i + 3] * knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
-         2 * knot_vect[i + 2] * knot_vect[i + 4] /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)) +
-         pow(knot_vect[i + 4], 2) /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
-    c2 = coeff_vect[i] *
-        (-knot_vect[i + 0] /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
-         2 * knot_vect[i + 3] /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) -
-         knot_vect[i + 1] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
-         knot_vect[i + 3] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
-         knot_vect[i + 4] /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) -
-         knot_vect[i + 2] /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)) -
-         2 * knot_vect[i + 4] /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
-    c3 = coeff_vect[i] *
-        (1 /
-             (-knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 2] +
-              knot_vect[i + 0] * knot_vect[i + 1] * knot_vect[i + 3] +
-              knot_vect[i + 0] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 0] * pow(knot_vect[i + 3], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 2] * pow(knot_vect[i + 3], 2) + pow(knot_vect[i + 3], 3)) +
-         1 /
-             (-pow(knot_vect[i + 1], 2) * knot_vect[i + 2] +
-              pow(knot_vect[i + 1], 2) * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * pow(knot_vect[i + 3], 2) -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 3], 2) * knot_vect[i + 4]) +
-         1 /
-             (-knot_vect[i + 1] * pow(knot_vect[i + 2], 2) +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-              knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] -
-              knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] +
-              pow(knot_vect[i + 2], 2) * knot_vect[i + 4] -
-              knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-              knot_vect[i + 2] * pow(knot_vect[i + 4], 2) +
-              knot_vect[i + 3] * pow(knot_vect[i + 4], 2)));
-
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    row.push_back(c3);
-    c0 = coeff_vect[i] *
-        (pow(knot_vect[i + 4], 3) /
-         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
-          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
-          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
-          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
-    c1 = coeff_vect[i] *
-        (-3 * pow(knot_vect[i + 4], 2) /
-         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
-          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
-          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
-          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
-    c2 = coeff_vect[i] *
-        (3 * knot_vect[i + 4] /
-         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
-          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
-          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
-          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
-    c3 = coeff_vect[i] *
-        (-1 /
-         (-knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 3] +
-          knot_vect[i + 1] * knot_vect[i + 2] * knot_vect[i + 4] +
-          knot_vect[i + 1] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 1] * pow(knot_vect[i + 4], 2) +
-          knot_vect[i + 2] * knot_vect[i + 3] * knot_vect[i + 4] -
-          knot_vect[i + 2] * pow(knot_vect[i + 4], 2) -
-          knot_vect[i + 3] * pow(knot_vect[i + 4], 2) + pow(knot_vect[i + 4], 3)));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    row.push_back(c3);
-    constants.push_back(row);
-  }
-
-  // Cache derivative constants
-
-  for (int i = 0; i < dnknot_vect.size() - 3; i++) {
-    std::vector<double> row;
-    c0 = dncoeff_vect[i] *
-        (pow(dnknot_vect[i + 0], 2) /
-         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
-          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
-    c1 = dncoeff_vect[i] *
-        (-2 * dnknot_vect[i + 0] /
-         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
-          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
-    c2 = dncoeff_vect[i] *
-        (1 /
-         (pow(dnknot_vect[i + 0], 2) - dnknot_vect[i + 0] * dnknot_vect[i + 1] -
-          dnknot_vect[i + 0] * dnknot_vect[i + 2] + dnknot_vect[i + 1] * dnknot_vect[i + 2]));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    c0 = dncoeff_vect[i] *
-        (-dnknot_vect[i + 1] * dnknot_vect[i + 3] /
-             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) -
-         dnknot_vect[i + 0] * dnknot_vect[i + 2] /
-             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
-    c1 = dncoeff_vect[i] *
-        (dnknot_vect[i + 1] /
-             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) +
-         dnknot_vect[i + 3] /
-             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) +
-         dnknot_vect[i + 0] /
-             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)) +
-         dnknot_vect[i + 2] /
-             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
-    c2 = dncoeff_vect[i] *
-        (-1 /
-             (pow(dnknot_vect[i + 1], 2) - dnknot_vect[i + 1] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 3] + dnknot_vect[i + 2] * dnknot_vect[i + 3]) -
-         1 /
-             (dnknot_vect[i + 0] * dnknot_vect[i + 1] - dnknot_vect[i + 0] * dnknot_vect[i + 2] -
-              dnknot_vect[i + 1] * dnknot_vect[i + 2] + pow(dnknot_vect[i + 2], 2)));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    c0 = dncoeff_vect[i] *
-        (pow(dnknot_vect[i + 3], 2) /
-         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
-          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
-    c1 = dncoeff_vect[i] *
-        (-2 * dnknot_vect[i + 3] /
-         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
-          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
-    c2 = dncoeff_vect[i] *
-        (1 /
-         (dnknot_vect[i + 1] * dnknot_vect[i + 2] - dnknot_vect[i + 1] * dnknot_vect[i + 3] -
-          dnknot_vect[i + 2] * dnknot_vect[i + 3] + pow(dnknot_vect[i + 3], 2)));
-    row.push_back(c0);
-    row.push_back(c1);
-    row.push_back(c2);
-    dconstants.push_back(row);
-  }
+  // Initialize B-Spline Derivative Basis Functions
+  for (int i = 0; i < dnknot_vect.size() - 3; i++)
+    dnbspline_bases.push_back(uf3_bspline_basis2(lmp, &dnknot_vect[i], dncoeff_vect[i]));
 }
 
 uf3_pair_bspline::~uf3_pair_bspline() {}
 
-//value function definition
-//input -->rij; output -->value on the bspline curve
-double uf3_pair_bspline::bsvalue(double value_rij)
+double *uf3_pair_bspline::eval(double r)
 {
-  //utils::logmesg(lmp,"return this value {}",this->uf3_pair_bspline::main_eval_loop(value_rij,bspline_degree,knot_vect,
-  //                                                coeff_vect));
-  return this->uf3_pair_bspline::main_eval_loop(value_rij, bspline_degree, knot_vect, coeff_vect);
-}
 
-double uf3_pair_bspline::bsderivative(double value_rij)
-{
-  if (bspline_degree < 1) {
-    return 0;
-  } else {
-    return this->uf3_pair_bspline::main_eval_loop(value_rij, bspline_degree - 1, dnknot_vect,
-                                                  dncoeff_vect);
-  }
-}
+  // Find knot starting position
 
-double uf3_pair_bspline::main_eval_loop(double r, int ibspline_degree,
-                                        const std::vector<double> &iknot_vect,
-                                        const std::vector<double> &icoeff_vect)
-{
-  int ipos_i = 0;
-  int iknot_mult = 0;
-  h = 0;
-  max_count = 0;
-  knot_affect_start = 0;
-  knot_affect_end = 0;
-  temp2 = 0;
-  temp3 = 0;
-  temp_val = 0;
-  if (iknot_vect.front() <= r && r < iknot_vect.back()) {
+  int start_index;
+  if (knot_vect.front() <= r && r < knot_vect.back()) {
     //Determine the interval for value_rij
-    for (int i = 0; i < knot_vect_size - 1; ++i) {
-      if (iknot_vect[i] <= r && r < iknot_vect[i + 1]) {
-        ipos_i = i;
+    for (int i = 3; i < knot_vect_size - 1; ++i) {
+      if (knot_vect[i] <= r && r < knot_vect[i + 1]) {
+        start_index = i;
         break;
       }
     }
   }
-  //#---------------------
-  //#----main eval loop---
-  //#---------------------
-  knot_affect_start = ipos_i - ibspline_degree;
+
+  int knot_affect_start = start_index - 3;
 
   double rsq = r * r;
   double rth = rsq * r;
 
-  if (ibspline_degree == 3) {
-    temp_val = rth * constants[knot_affect_start + 3][3] +
-        rsq * constants[knot_affect_start + 3][2] + r * constants[knot_affect_start + 3][1] +
-        constants[knot_affect_start + 3][0];
-    temp_val += rth * constants[knot_affect_start + 2][7] +
-        rsq * constants[knot_affect_start + 2][6] + r * constants[knot_affect_start + 2][5] +
-        constants[knot_affect_start + 2][4];
-    temp_val += rth * constants[knot_affect_start + 1][11] +
-        rsq * constants[knot_affect_start + 1][10] + r * constants[knot_affect_start + 1][9] +
-        constants[knot_affect_start + 1][8];
-    temp_val += rth * constants[knot_affect_start + 0][15] +
-        rsq * constants[knot_affect_start + 0][14] + r * constants[knot_affect_start + 0][13] +
-        constants[knot_affect_start + 0][12];
-    return temp_val;
-  }
+  // Calculate energy
 
-  else if (ibspline_degree == 2) {
-    temp_val = rsq * dconstants[knot_affect_start + 2][2] +
-        r * dconstants[knot_affect_start + 2][1] + dconstants[knot_affect_start + 2][0];
-    temp_val += rsq * dconstants[knot_affect_start + 1][5] +
-        r * dconstants[knot_affect_start + 1][4] + dconstants[knot_affect_start + 1][3];
-    temp_val += rsq * dconstants[knot_affect_start + 0][8] +
-        r * dconstants[knot_affect_start + 0][7] + dconstants[knot_affect_start + 0][6];
-    return temp_val;
-  }
+  ret_val[0] = bspline_bases[knot_affect_start + 3].eval0(rth, rsq, r);
+  ret_val[0] += bspline_bases[knot_affect_start + 2].eval1(rth, rsq, r);
+  ret_val[0] += bspline_bases[knot_affect_start + 1].eval2(rth, rsq, r);
+  ret_val[0] += bspline_bases[knot_affect_start].eval3(rth, rsq, r);
 
-  return 0;
+  // Calculate force
+
+  ret_val[1] = dnbspline_bases[knot_affect_start + 2].eval0(rsq, r);
+  ret_val[1] += dnbspline_bases[knot_affect_start + 1].eval1(rsq, r);
+  ret_val[1] += dnbspline_bases[knot_affect_start].eval2(rsq, r);
+
+  return ret_val;
 }

--- a/lammps_plugin/ML-UF3/uf3_pair_bspline.h
+++ b/lammps_plugin/ML-UF3/uf3_pair_bspline.h
@@ -1,10 +1,23 @@
-//De Boor's algorithm @
-//https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/de-Boor.html
-//For values outside the domain,
-//extrapoltaes the left(right) hand side piece of the curve
-//Only works for bspline degree upto 3 becuase of definiation of P
-//
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/ Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// De Boor's algorithm @
+// https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/de-Boor.html
+// For values outside the domain, it exhibits undefined behavior.
+// Uses fixed B-Spline degree 3.
+
 #include "pointers.h"
+
+#include "uf3_bspline_basis2.h"
+#include "uf3_bspline_basis3.h"
 
 #include <vector>
 
@@ -15,28 +28,21 @@ namespace LAMMPS_NS {
 
 class uf3_pair_bspline {
  private:
-  int bspline_degree;
   int knot_vect_size, coeff_vect_size;
   std::vector<double> knot_vect, dnknot_vect;
   std::vector<double> coeff_vect, dncoeff_vect;
-  int pos_i, h, knot_mult, max_count, knot_affect_start, knot_affect_end;
-  double temp2, temp3, dntemp4, temp_val;
-  //Make P's; size of P is max of what will ever be needed
-  double P[4][4] = {};
+  std::vector<uf3_bspline_basis3> bspline_bases;
+  std::vector<uf3_bspline_basis2> dnbspline_bases;
   LAMMPS *lmp;
-  //double main_eval_loop(double ivalue_rij,int ibspline_degree,std::vector<double> iknot_vect,
-  //			std::vector<double> icoeff_vect, int ipos_i, int iknot_mult);
+
  public:
   // dummy constructor
   uf3_pair_bspline();
-  uf3_pair_bspline(LAMMPS *ulmp, int ubspline_degree, const std::vector<double> &uknot_vect,
+  uf3_pair_bspline(LAMMPS *ulmp, const std::vector<double> &uknot_vect,
                    const std::vector<double> &ucoeff_vect);
   ~uf3_pair_bspline();
-  double bsvalue(double value_rij);
-  double bsderivative(double value_rij);
-  double main_eval_loop(double ivalue_rij, int ibspline_degree,
-                        const std::vector<double> &iknot_vect,
-                        const std::vector<double> &icoeff_vect);
+  double ret_val[2];
+  double *eval(double value_rij);
 };
 }    // namespace LAMMPS_NS
 #endif

--- a/lammps_plugin/ML-UF3/uf3_pair_bspline.h
+++ b/lammps_plugin/ML-UF3/uf3_pair_bspline.h
@@ -1,42 +1,42 @@
 //De Boor's algorithm @
 //https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/de-Boor.html
-//For values outside the domain, 
+//For values outside the domain,
 //extrapoltaes the left(right) hand side piece of the curve
 //Only works for bspline degree upto 3 becuase of definiation of P
 //
 #include "pointers.h"
 
-#include <vector> 
+#include <vector>
 
-#ifndef UF3_PAIR_BSPLINE_H 
+#ifndef UF3_PAIR_BSPLINE_H
 #define UF3_PAIR_BSPLINE_H
 
 namespace LAMMPS_NS {
 
-class uf3_pair_bspline
-{
-private:
-	int bspline_degree;
-	int knot_vect_size, coeff_vect_size; 
-	std::vector<double> knot_vect, dnknot_vect;
-	std::vector<double> coeff_vect, dncoeff_vect;
-	int pos_i, h, knot_mult, max_count, knot_affect_start, knot_affect_end;
-	double temp2, temp3, dntemp4,temp_val;
-	//Make P's; size of P is max of what will ever be needed
-	double P[4][4] = {};
-	LAMMPS* lmp;
-	//double main_eval_loop(double ivalue_rij,int ibspline_degree,std::vector<double> iknot_vect,
-	//			std::vector<double> icoeff_vect, int ipos_i, int iknot_mult);
-public:
-	// dummy constructor
-	uf3_pair_bspline();
-	uf3_pair_bspline(LAMMPS* ulmp, int ubspline_degree,
-				const std::vector<double> &uknot_vect, const std::vector<double> &ucoeff_vect);
-	~uf3_pair_bspline();
-	double bsvalue(double value_rij);
-	double bsderivative(double value_rij);
-	double main_eval_loop(double ivalue_rij,int ibspline_degree,const std::vector<double> &iknot_vect,
-				const std::vector<double> &icoeff_vect);
+class uf3_pair_bspline {
+ private:
+  int bspline_degree;
+  int knot_vect_size, coeff_vect_size;
+  std::vector<double> knot_vect, dnknot_vect;
+  std::vector<double> coeff_vect, dncoeff_vect;
+  int pos_i, h, knot_mult, max_count, knot_affect_start, knot_affect_end;
+  double temp2, temp3, dntemp4, temp_val;
+  //Make P's; size of P is max of what will ever be needed
+  double P[4][4] = {};
+  LAMMPS *lmp;
+  //double main_eval_loop(double ivalue_rij,int ibspline_degree,std::vector<double> iknot_vect,
+  //			std::vector<double> icoeff_vect, int ipos_i, int iknot_mult);
+ public:
+  // dummy constructor
+  uf3_pair_bspline();
+  uf3_pair_bspline(LAMMPS *ulmp, int ubspline_degree, const std::vector<double> &uknot_vect,
+                   const std::vector<double> &ucoeff_vect);
+  ~uf3_pair_bspline();
+  double bsvalue(double value_rij);
+  double bsderivative(double value_rij);
+  double main_eval_loop(double ivalue_rij, int ibspline_degree,
+                        const std::vector<double> &iknot_vect,
+                        const std::vector<double> &icoeff_vect);
 };
-}
+}    // namespace LAMMPS_NS
 #endif

--- a/lammps_plugin/ML-UF3/uf3_triplet_bspline.cpp
+++ b/lammps_plugin/ML-UF3/uf3_triplet_bspline.cpp
@@ -1,86 +1,231 @@
 #include "uf3_triplet_bspline.h"
-#include <vector>
 #include <iostream>
+#include <vector>
 
 using namespace LAMMPS_NS;
 
-//Dummy constructor
-uf3_triplet_bspline::uf3_triplet_bspline(){}
+// Dummy constructor
+uf3_triplet_bspline::uf3_triplet_bspline(){};
 
-//Call constructor
-uf3_triplet_bspline::uf3_triplet_bspline(LAMMPS* ulmp, const std::vector<std::vector<double>> &uknot_matrix,
-			const std::vector<std::vector<std::vector<double>>> &ucoeff_matrix){
-	lmp = ulmp;
-	knot_matrix = uknot_matrix;
-	coeff_matrix = ucoeff_matrix;
-	alpha.resize(coeff_matrix.size()+1);
-	alpha_3rd_term.resize(coeff_matrix.size()+1);
-	for(int l=0; l<coeff_matrix.size();l++){
-		alpha[l].resize(coeff_matrix[l].size());
-		alpha_3rd_term[l].resize(coeff_matrix[l].size());
-	}
-	alpha[coeff_matrix.size()].resize(coeff_matrix.size());
-	alpha_2nd_term.resize(coeff_matrix.size());
-	alpha_3rd_term[coeff_matrix.size()].resize(coeff_matrix.size());
+// Construct a new 3D B-Spline
+uf3_triplet_bspline::uf3_triplet_bspline(
+    LAMMPS *ulmp, const std::vector<std::vector<double>> &uknot_matrix,
+    const std::vector<std::vector<std::vector<double>>> &ucoeff_matrix)
+{
+  lmp = ulmp;
+  knot_matrix = uknot_matrix;
+  coeff_matrix = ucoeff_matrix;
+
+  knot_vect_size_ij = knot_matrix[2].size();
+  knot_vect_size_ik = knot_matrix[1].size();
+  knot_vect_size_jk = knot_matrix[0].size();
+
+  int resolution_ij = knot_vect_size_ij - 4;
+  int resolution_ik = knot_vect_size_ik - 4;
+  int resolution_jk = knot_vect_size_jk - 4;
+
+  // Cache Spline Basis Functions
+  for (int l = 0; l < resolution_ij; l++) {
+    bsplines_ij.push_back(uf3_bspline_basis3(lmp, &knot_matrix[2][l], 1));
+  }
+
+  for (int l = 0; l < resolution_ik; l++) {
+    // Reuse jk Basis if Knots match
+    if (knot_matrix[1][l] == knot_matrix[2][l] && knot_matrix[1][l + 1] == knot_matrix[2][l + 1] &&
+        knot_matrix[1][l + 2] == knot_matrix[2][l + 2] &&
+        knot_matrix[1][l + 3] == knot_matrix[2][l + 3])
+      bsplines_ik.push_back(bsplines_ij[l]);
+    else
+      bsplines_ik.push_back(uf3_bspline_basis3(lmp, &knot_matrix[1][l], 1));
+  }
+
+  for (int l = 0; l < resolution_jk; l++) {
+    bsplines_jk.push_back(uf3_bspline_basis3(lmp, &knot_matrix[0][l], 1));
+  }
+
+  // Initialize Coefficients for Derivatives
+  for (int i = 0; i < coeff_matrix.size(); i++) {
+    std::vector<std::vector<double>> dncoeff_vect2;
+    for (int j = 0; j < coeff_matrix[0].size(); j++) {
+      std::vector<double> dncoeff_vect;
+      for (int k = 0; k < coeff_matrix[0][0].size() - 1; k++) {
+        double dntemp4 = 3 / (knot_matrix[0][k + 4] - knot_matrix[0][k + 1]);
+        dncoeff_vect.push_back((coeff_matrix[i][j][k + 1] - coeff_matrix[i][j][k]) * dntemp4);
+      }
+      dncoeff_vect2.push_back(dncoeff_vect);
+    }
+    dncoeff_matrix_jk.push_back(dncoeff_vect2);
+  }
+
+  for (int i = 0; i < coeff_matrix.size(); i++) {
+    std::vector<std::vector<double>> dncoeff_vect2;
+    for (int j = 0; j < coeff_matrix[0].size() - 1; j++) {
+      double dntemp4 = 3 / (knot_matrix[1][j + 4] - knot_matrix[1][j + 1]);
+      std::vector<double> dncoeff_vect;
+      for (int k = 0; k < coeff_matrix[0][0].size(); k++) {
+        dncoeff_vect.push_back((coeff_matrix[i][j + 1][k] - coeff_matrix[i][j][k]) * dntemp4);
+      }
+      dncoeff_vect2.push_back(dncoeff_vect);
+    }
+    dncoeff_matrix_ik.push_back(dncoeff_vect2);
+  }
+
+  for (int i = 0; i < coeff_matrix.size() - 1; i++) {
+    std::vector<std::vector<double>> dncoeff_vect2;
+    double dntemp4 = 3 / (knot_matrix[2][i + 4] - knot_matrix[2][i + 1]);
+    for (int j = 0; j < coeff_matrix[0].size(); j++) {
+      std::vector<double> dncoeff_vect;
+      for (int k = 0; k < coeff_matrix[0][0].size(); k++) {
+        dncoeff_vect.push_back((coeff_matrix[i + 1][j][k] - coeff_matrix[i][j][k]) * dntemp4);
+      }
+      dncoeff_vect2.push_back(dncoeff_vect);
+    }
+    dncoeff_matrix_ij.push_back(dncoeff_vect2);
+  }
+
+  std::vector<std::vector<double>> dnknot_matrix;
+  for (int i = 0; i < knot_matrix.size(); i++) {
+    std::vector<double> dnknot_vect;
+    for (int j = 1; j < knot_matrix[0].size() - 1; j++) {
+      dnknot_vect.push_back(knot_matrix[i][j]);
+    }
+    dnknot_matrix.push_back(dnknot_vect);
+  }
+
+  // Cache Derivative Spline Basis Functions
+  for (int l = 0; l < resolution_ij - 1; l++) {
+    dnbsplines_ij.push_back(uf3_bspline_basis2(lmp, &dnknot_matrix[2][l], 1));
+  }
+
+  for (int l = 0; l < resolution_ik - 1; l++) {
+    // Reuse jk Basis if Knots match
+    if (dnknot_matrix[1][l] == dnknot_matrix[2][l] &&
+        dnknot_matrix[1][l + 1] == dnknot_matrix[2][l + 1] &&
+        dnknot_matrix[1][l + 2] == dnknot_matrix[2][l + 2])
+      dnbsplines_ik.push_back(dnbsplines_ij[l]);
+    else
+      dnbsplines_ik.push_back(uf3_bspline_basis2(lmp, &dnknot_matrix[1][l], 1));
+  }
+
+  for (int l = 0; l < resolution_jk - 1; l++) {
+    dnbsplines_jk.push_back(uf3_bspline_basis2(lmp, &dnknot_matrix[0][l], 1));
+  }
 }
 
-//Destructor
-uf3_triplet_bspline::~uf3_triplet_bspline(){}
+// Destructor
+uf3_triplet_bspline::~uf3_triplet_bspline() {}
 
-double uf3_triplet_bspline::bsvalue(double value_rij,double value_rik,double value_rjk){
-	this->uf3_triplet_bspline::main_eval(value_rij, value_rik, value_rjk);
-	return return_val[0];
+// Evaluate 3D B-Spline value
+double *uf3_triplet_bspline::eval(double value_rij, double value_rik, double value_rjk)
+{
+
+  // Find starting knots
+
+  int iknot_ij = starting_knot(knot_matrix[2], knot_vect_size_ij, value_rij) - 3;
+  int iknot_ik = starting_knot(knot_matrix[1], knot_vect_size_ik, value_rik) - 3;
+  int iknot_jk = starting_knot(knot_matrix[0], knot_vect_size_jk, value_rjk) - 3;
+
+  double rsq_ij = value_rij * value_rij;
+  double rsq_ik = value_rik * value_rik;
+  double rsq_jk = value_rjk * value_rjk;
+  double rth_ij = rsq_ij * value_rij;
+  double rth_ik = rsq_ik * value_rik;
+  double rth_jk = rsq_jk * value_rjk;
+
+  // Calculate energies
+
+  double basis_ij[4];
+  basis_ij[0] = bsplines_ij[iknot_ij].eval3(rth_ij, rsq_ij, value_rij);
+  basis_ij[1] = bsplines_ij[iknot_ij + 1].eval2(rth_ij, rsq_ij, value_rij);
+  basis_ij[2] = bsplines_ij[iknot_ij + 2].eval1(rth_ij, rsq_ij, value_rij);
+  basis_ij[3] = bsplines_ij[iknot_ij + 3].eval0(rth_ij, rsq_ij, value_rij);
+
+  double basis_ik[4];
+  basis_ik[0] = bsplines_ik[iknot_ik].eval3(rth_ik, rsq_ik, value_rik);
+  basis_ik[1] = bsplines_ik[iknot_ik + 1].eval2(rth_ik, rsq_ik, value_rik);
+  basis_ik[2] = bsplines_ik[iknot_ik + 2].eval1(rth_ik, rsq_ik, value_rik);
+  basis_ik[3] = bsplines_ik[iknot_ik + 3].eval0(rth_ik, rsq_ik, value_rik);
+
+  double basis_jk[4];
+  basis_jk[0] = bsplines_jk[iknot_jk].eval3(rth_jk, rsq_jk, value_rjk);
+  basis_jk[1] = bsplines_jk[iknot_jk + 1].eval2(rth_jk, rsq_jk, value_rjk);
+  basis_jk[2] = bsplines_jk[iknot_jk + 2].eval1(rth_jk, rsq_jk, value_rjk);
+  basis_jk[3] = bsplines_jk[iknot_jk + 3].eval0(rth_jk, rsq_jk, value_rjk);
+
+  ret_val[0] = 0;
+  ret_val[1] = 0;
+  ret_val[2] = 0;
+  ret_val[3] = 0;
+
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      for (int k = 0; k < 4; k++) {
+        ret_val[0] += coeff_matrix[i + iknot_ij][j + iknot_ik][k + iknot_jk] * basis_ij[i] *
+            basis_ik[j] * basis_jk[k];
+      }
+    }
+  }
+
+  // Calculate forces
+
+  double dnbasis_ij[4];
+  dnbasis_ij[0] = dnbsplines_ij[iknot_ij].eval2(rsq_ij, value_rij);
+  dnbasis_ij[1] = dnbsplines_ij[iknot_ij + 1].eval1(rsq_ij, value_rij);
+  dnbasis_ij[2] = dnbsplines_ij[iknot_ij + 2].eval0(rsq_ij, value_rij);
+  dnbasis_ij[3] = 0;
+
+  double dnbasis_ik[4];
+  dnbasis_ik[0] = dnbsplines_ik[iknot_ik].eval2(rsq_ik, value_rik);
+  dnbasis_ik[1] = dnbsplines_ik[iknot_ik + 1].eval1(rsq_ik, value_rik);
+  dnbasis_ik[2] = dnbsplines_ik[iknot_ik + 2].eval0(rsq_ik, value_rik);
+  dnbasis_ik[3] = 0;
+
+  double dnbasis_jk[4];
+  dnbasis_jk[0] = dnbsplines_jk[iknot_jk].eval2(rsq_jk, value_rjk);
+  dnbasis_jk[1] = dnbsplines_jk[iknot_jk + 1].eval1(rsq_jk, value_rjk);
+  dnbasis_jk[2] = dnbsplines_jk[iknot_jk + 2].eval0(rsq_jk, value_rjk);
+  dnbasis_jk[3] = 0;
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 4; j++) {
+      for (int k = 0; k < 4; k++) {
+        ret_val[1] += dncoeff_matrix_ij[iknot_ij + i][iknot_ik + j][iknot_jk + k] * dnbasis_ij[i] *
+            basis_ik[j] * basis_jk[k];
+      }
+    }
+  }
+
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 3; j++) {
+      for (int k = 0; k < 4; k++) {
+        ret_val[2] += dncoeff_matrix_ik[iknot_ij + i][iknot_ik + j][iknot_jk + k] * basis_ij[i] *
+            dnbasis_ik[j] * basis_jk[k];
+      }
+    }
+  }
+
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      for (int k = 0; k < 3; k++) {
+        ret_val[3] += dncoeff_matrix_jk[iknot_ij + i][iknot_ik + j][iknot_jk + k] * basis_ij[i] *
+            basis_ik[j] * dnbasis_jk[k];
+      }
+    }
+  }
+
+  return ret_val;
 }
 
-double* uf3_triplet_bspline::bsvalue_bsderivative(double value_rij,double value_rik,double value_rjk){
-	//this->uf3_triplet_bspline::main_eval(value_rij, value_rik, value_rjk);
-	bsderivative_return_val[0] = return_val[1];
-	bsderivative_return_val[1] = return_val[2];
-	bsderivative_return_val[2] = return_val[3];
-	return bsderivative_return_val;
+// Find starting knot for spline evaluation
 
+int uf3_triplet_bspline::starting_knot(const std::vector<double> knot_vect, int knot_vect_size,
+                                       double r)
+{
+  if (knot_vect.front() <= r && r < knot_vect.back()) {
+    for (int i = 3; i < knot_vect_size - 1; i++) {
+      if (knot_vect[i] <= r && r < knot_vect[i + 1]) return i;
+    }
+  }
+
+  return 0;
 }
-
-void uf3_triplet_bspline::main_eval(double ivalue_rij,double ivalue_rik,double ivalue_rjk){
-	//static double return_val[4];
-	//alpha.resize(coeff_matrix.size()+1);
-	//alpha_3rd_term.resize(coeff_matrix.size()+1);
-	for(int l=0; l<coeff_matrix.size();l++){
-		//alpha[l].resize(coeff_matrix[l].size());
-		//alpha_3rd_term[l].resize(coeff_matrix[l].size());
-		for(int m=0; m<coeff_matrix[l].size();m++){
-			UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[0],coeff_matrix[l][m]);
-			alpha[l][m] = UF3Pair.bsvalue(ivalue_rjk);
-			alpha_3rd_term[l][m] = UF3Pair.bsderivative(ivalue_rjk);
-		}
-	}
-	//alpha[coeff_matrix.size()].resize(coeff_matrix.size());
-	//alpha_2nd_term.resize(coeff_matrix.size());
-	//alpha_3rd_term[coeff_matrix.size()].resize(coeff_matrix.size());
-	for(int l=0; l<coeff_matrix.size();l++){
-		UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[1],alpha[l]);
-		alpha[coeff_matrix.size()][l] = UF3Pair.bsvalue(ivalue_rik);
-		alpha_2nd_term[l] = UF3Pair.bsderivative(ivalue_rik);
-		
-		UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[1],alpha_3rd_term[l]);
-		alpha_3rd_term[coeff_matrix.size()][l] = UF3Pair.bsvalue(ivalue_rik);
-	}
-	UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[2],alpha[coeff_matrix.size()]);
-	return_val[0] = UF3Pair.bsvalue(ivalue_rij);
-	
-	d1st_term = UF3Pair.bsderivative(ivalue_rij);
-	
-	UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[2],alpha_2nd_term);
-	d2nd_term = UF3Pair.bsvalue(ivalue_rij);
-	
-	UF3Pair = uf3_pair_bspline(lmp,3,knot_matrix[2],alpha_3rd_term[coeff_matrix.size()]);
-	d3rd_term = UF3Pair.bsvalue(ivalue_rij);
-
-	//derivative = d1st_term + d2nd_term + d3rd_term;
-	return_val[1] = d1st_term;
-	return_val[2] = d2nd_term;
-	return_val[3] = d3rd_term;
-	//return return_val;
-}
-
-

--- a/lammps_plugin/ML-UF3/uf3_triplet_bspline.h
+++ b/lammps_plugin/ML-UF3/uf3_triplet_bspline.h
@@ -1,42 +1,46 @@
-//Simple implementation of 3d bspline
-//Takes knot, coeff matrix and (rij,rik,rjk) as input and returns V3 and V'3 as the output
-//Repetitive calls uf3_pair_bspline 
-//
-//
-//
-#include  "pointers.h"
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/ Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
 
-#include <vector>
+#include "pointers.h"
+
+#include "uf3_bspline_basis2.h"
+#include "uf3_bspline_basis3.h"
 #include "uf3_pair_bspline.h"
 
-#ifndef UF3_TRIPLET_BSPLINE_H 
+#include <vector>
+
+#ifndef UF3_TRIPLET_BSPLINE_H
 #define UF3_TRIPLET_BSPLINE_H
 
 namespace LAMMPS_NS {
-class uf3_triplet_bspline
-{
-private:
-	std::vector<std::vector<std::vector<double>>> coeff_matrix;
-	std::vector<std::vector<double>> knot_matrix;
-	std::vector<std::vector<double>> alpha, alpha_3rd_term;
-	std::vector<double> alpha_2nd_term;
-	uf3_pair_bspline UF3Pair;
-	double d1st_term, d2nd_term, d3rd_term, derivative;
-	double bsderivative_return_val[3];
-	double return_val[4];
-	LAMMPS* lmp;
-public:
-	//Dummy Constructor
-	uf3_triplet_bspline();
-	uf3_triplet_bspline(LAMMPS* ulmp, const std::vector<std::vector<double>> &uknot_matrix,
-			const std::vector<std::vector<std::vector<double>>> &ucoeff_matrix);
-	//uf3_triplet_bspline(double *uknot_matrix_start, int uknot_matrix_shape[3], 
-	//			double *ucoeff_matrix_start, int ucoeff_matrix_shape[3]);
-	~uf3_triplet_bspline();
-	double bsvalue(double value_rij,double value_rik,double value_rjk);
-	double* bsvalue_bsderivative(double value_rij,double value_rik,double value_rjk);
-	void main_eval(double ivalue_rij,double ivalue_rik,double ivalue_rjk);
-	//static double return_val[2];
+class uf3_triplet_bspline {
+ private:
+  LAMMPS *lmp;
+  int knot_vect_size_ij, knot_vect_size_ik, knot_vect_size_jk;
+  std::vector<std::vector<std::vector<double>>> coeff_matrix, dncoeff_matrix_ij, dncoeff_matrix_ik,
+      dncoeff_matrix_jk;
+  std::vector<std::vector<double>> knot_matrix;
+  std::vector<uf3_bspline_basis3> bsplines_ij, bsplines_ik, bsplines_jk;
+  std::vector<uf3_bspline_basis2> dnbsplines_ij, dnbsplines_ik, dnbsplines_jk;
+  double ret_val[4];
+
+  int starting_knot(const std::vector<double>, int, double);
+
+ public:
+  //Dummy Constructor
+  uf3_triplet_bspline();
+  uf3_triplet_bspline(LAMMPS *ulmp, const std::vector<std::vector<double>> &uknot_matrix,
+                      const std::vector<std::vector<std::vector<double>>> &ucoeff_matrix);
+  ~uf3_triplet_bspline();
+  double *eval(double value_rij, double value_rik, double value_rjk);
 };
-}
+}    // namespace LAMMPS_NS
 #endif


### PR DESCRIPTION
I have introduced caching for the constants in the explicit non-recursive form of B-Splines.
For this, there are two new classes: `uf3_bspline_basis2` and `uf3_bspline_basis3` for B-Splines of degrees 2 and 3.
To incorporate them into the pair and triplet classes, the degree there is now fixed to 3.

Furthermore, I have removed the safety checks that handle values outside the domain. If the classes are only used by the main class and have the cutoffs handled there, they shouldn't be necessary.

The most significant speed improvement comes from not evaluating all splines in the triplet over two dimensions, but rather only the 12 that are actually required.

In my tests, there are very minor differences in forces, energies, and stresses but they are due to limited double precision.
The speed-up I was able to achieve in a 40k steps simulation was a factor of ~150.

 The code now respects the .clang-format standards set by LAMMPS.